### PR TITLE
fix(cli): bad state error on no argument

### DIFF
--- a/bin/stacked.dart
+++ b/bin/stacked.dart
@@ -54,10 +54,7 @@ Future<void> main(List<String> arguments) async {
 
     if (_handleAnalytics(argResults)) exit(0);
 
-    // Ignore notify version for compile and update commands
-    if (arguments.first != 'compile' && arguments.first != 'update') {
-      await _notifyNewVersionAvailable();
-    }
+    await _notifyNewVersionAvailable(arguments: arguments);
 
     runner.run(arguments);
   } on InvalidStackedStructureException catch (e) {
@@ -119,7 +116,17 @@ Future<void> _handleFirstRun() async {
   analyticsService.enable(opt == 'y' || opt == 'yes');
 }
 
-Future<void> _notifyNewVersionAvailable() async {
+/// Notifies new version of Stacked CLI is available
+Future<void> _notifyNewVersionAvailable({
+  List<String> arguments = const [],
+  List<String> ignored = const ['compile', 'update'],
+}) async {
+  if (arguments.isEmpty) return;
+
+  for (var arg in ignored) {
+    if (arguments.first == arg) return;
+  }
+
   if (await locator<PubService>().hasLatestVersion()) return;
 
   stdout.writeln('''

--- a/lib/src/services/pub_service.dart
+++ b/lib/src/services/pub_service.dart
@@ -14,7 +14,7 @@ class PubService {
 
   /// Returns current `stacked_cli` version installed on the system.
   Future<String> getCurrentVersion() async {
-    late String version;
+    String version = 'Current Version Not Available';
 
     final packages = await _processService.runPubGlobalList();
     for (var package in packages) {


### PR DESCRIPTION
- Avoid `Bad state: No element` when no argument passed to the CLI
- Refactor of the code for a cleaner implementation
- Add default value to version on getCurrentVersion to avoid LateInitializationError when no package found