### PR TITLE
fix(cli): update deprecated property on view templates

### DIFF
--- a/lib/src/templates/compiled_templates.dart
+++ b/lib/src/templates/compiled_templates.dart
@@ -3439,7 +3439,7 @@ class {{viewName}} extends StackedView<{{viewModelName}}> {
     Widget? child,
   ) {
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: Container(
         padding: const EdgeInsets.only(left: 25.0, right: 25.0),
       ),
@@ -3475,7 +3475,7 @@ class {{viewName}} extends StatelessWidget {
     return ViewModelBuilder<{{viewModelName}}>.reactive(
       viewModelBuilder: () => {{viewModelName}}(),
       builder: (context, model, child) => Scaffold(
-        backgroundColor: Theme.of(context).backgroundColor,
+        backgroundColor: Theme.of(context).colorScheme.background,
         body: Container(
           padding: const EdgeInsets.only(left: 25.0, right: 25.0),
         ),

--- a/lib/src/templates/view/empty/lib/ui/views/generic/generic_view.dart.stk
+++ b/lib/src/templates/view/empty/lib/ui/views/generic/generic_view.dart.stk
@@ -13,7 +13,7 @@ class {{viewName}} extends StackedView<{{viewModelName}}> {
     Widget? child,
   ) {
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: Container(
         padding: const EdgeInsets.only(left: 25.0, right: 25.0),
       ),

--- a/lib/src/templates/view/empty/lib/ui/views/generic/generic_view_v1.dart.stk
+++ b/lib/src/templates/view/empty/lib/ui/views/generic/generic_view_v1.dart.stk
@@ -11,7 +11,7 @@ class {{viewName}} extends StatelessWidget {
     return ViewModelBuilder<{{viewModelName}}>.reactive(
       viewModelBuilder: () => {{viewModelName}}(),
       builder: (context, model, child) => Scaffold(
-        backgroundColor: Theme.of(context).backgroundColor,
+        backgroundColor: Theme.of(context).colorScheme.background,
         body: Container(
           padding: const EdgeInsets.only(left: 25.0, right: 25.0),
         ),


### PR DESCRIPTION
Replaced deprecated `backgroundColor` with `colorScheme.background`.