### PR TITLE
fix: flutter format depreciation in favor of dart format

### DIFF
--- a/lib/src/services/process_service.dart
+++ b/lib/src/services/process_service.dart
@@ -58,13 +58,13 @@ class ProcessService {
     );
   }
 
-  /// Runs the flutter format . command on the app's source code.
+  /// Runs the dart format . command on the app's source code.
   ///
   /// Args:
   ///   appName (String): The name of the app.
   Future<void> runFormat({String? appName, String? filePath}) async {
     await _runProcess(
-      programName: ksFlutter,
+      programName: ksDart,
       arguments: [
         ksFormat,
         filePath ?? ksCurrentDirectory,

--- a/test/services/process_service_test.dart
+++ b/test/services/process_service_test.dart
@@ -12,7 +12,7 @@ void main() {
     setUp(() => registerServices());
     tearDown(() => locator.reset());
     group('runFormat -', () {
-      test('when called should run flutter format . and finish in exit code 0',
+      test('when called should run dart format . and finish in exit code 0',
           () async {
         var clog = getAndRegisterColorizedLogService();
         var service = _getService();
@@ -21,7 +21,7 @@ void main() {
       });
 
       test(
-          'when called should run flutter format . and ouput error if appName is not found',
+          'when called should run dart format . and ouput error if appName is not found',
           () async {
         var clog = getAndRegisterColorizedLogService();
         var service = _getService();


### PR DESCRIPTION
## Issue 
Using last CLI version with Flutter v3.10 / Dart 3 `flutter format` command has been deprecated, giving errors in CLI and resulting in files not formatted. 

## Details

Using last CLI version with Flutter v3.10 / Dart 3, the create view command is giving the following output: 

```
stacked create view profile
templateType:null preferWeb:false
Created File: 'test/viewmodels/profile_viewmodel_test.dart'
Created File: 'lib/ui/views/profile/profile_viewmodel.dart'
Created File: 'lib/ui/views/profile/profile_view.dart'
Applied Modification Add ProfileView route where @StackedApp annotation is located
Applied Modification Add ProfileView route import where @StackedApp annotation is located
Running flutter format . -l 80 ...
Command complete. ExitCode: 1
Running flutter pub run build_runner build --delete-conflicting-outputs ...
[INFO] Generating build script...

[INFO] Generating build script completed, took 151ms


[INFO] Initializing inputs

[INFO] Reading cached asset graph...

[INFO] Reading cached asset graph completed, took 52ms


[INFO] Checking for updates since last build...

[INFO] Checking for updates since last build completed, took 515ms


[INFO] Running build...

[INFO] 1.0s elapsed, 0/4 actions completed.

[INFO] 6.4s elapsed, 3/4 actions completed.

[INFO] Running build completed, took 7.3s

[INFO] Caching finalized dependency graph...

[INFO] Caching finalized dependency graph completed, took 36ms


[INFO] Succeeded after 7.3s with 5 outputs (31 actions)


Command complete. ExitCode: 0
```

And the files are not formatted. 

When running only ` flutter format . -l 80`
The "format" command is deprecated. Please use the "dart format" sub-command instead, which has the same command-line usage as "flutter format".

This deprecation is fixed in this PR. 
Let me know if something is missing or not clear 😊

Thanks a lot!