### PR TITLE
fix: stacked config not used on commands

### DIFF
--- a/lib/src/commands/create/create_app_command.dart
+++ b/lib/src/commands/create/create_app_command.dart
@@ -105,10 +105,14 @@ class CreateAppCommand extends Command {
     _log.stackedOutput(message: 'Cleaning project...');
 
     // Removes `widget_test` file to avoid failing unit tests on created app
-    await _fileService.deleteFile(
+    if (await _fileService.fileExists(
       filePath: '$appName/test/widget_test.dart',
-      verbose: false,
-    );
+    )) {
+      await _fileService.deleteFile(
+        filePath: '$appName/test/widget_test.dart',
+        verbose: false,
+      );
+    }
 
     // Analyze the project and return output lines
     final issues = await _processService.runAnalyze(appName: appName);

--- a/lib/src/commands/create/create_app_command.dart
+++ b/lib/src/commands/create/create_app_command.dart
@@ -15,7 +15,7 @@ import 'package:stacked_cli/src/services/template_service.dart';
 import 'package:stacked_cli/src/templates/template_constants.dart';
 
 class CreateAppCommand extends Command {
-  final _cLog = locator<ColorizedLogService>();
+  final _log = locator<ColorizedLogService>();
   final _configService = locator<ConfigService>();
   final _fileService = locator<FileService>();
   final _processService = locator<ProcessService>();
@@ -57,14 +57,16 @@ class CreateAppCommand extends Command {
     argParser.addOption(
       ksConfigPath,
       abbr: 'c',
-      help: kCommandHelpCreateAppConfigFile,
+      help: kCommandHelpConfigFilePath,
     );
   }
 
   @override
   Future<void> run() async {
     try {
-      await _configService.loadConfig(path: argResults![ksConfigPath]);
+      await _configService.findAndLoadConfigFile(
+        configFilePath: argResults![ksConfigPath],
+      );
 
       final appName = argResults!.rest.first;
       final appNameWithoutPath = appName.split('/').last;
@@ -74,7 +76,7 @@ class CreateAppCommand extends Command {
       _processService.formattingLineLength = argResults![ksLineLength];
       await _processService.runCreateApp(appName: appName);
 
-      _cLog.stackedOutput(message: 'Add Stacked Magic ... ', isBold: true);
+      _log.stackedOutput(message: 'Add Stacked Magic ... ', isBold: true);
 
       await _templateService.renderTemplate(
         templateName: name,
@@ -91,7 +93,7 @@ class CreateAppCommand extends Command {
       await _processService.runFormat(appName: appName);
       await _clean(appName: appName);
     } catch (e) {
-      _cLog.warn(message: e.toString());
+      _log.warn(message: e.toString());
     }
   }
 
@@ -100,7 +102,7 @@ class CreateAppCommand extends Command {
   ///   - Deletes widget_test.dart file
   ///   - Removes unused imports
   Future<void> _clean({required String appName}) async {
-    _cLog.stackedOutput(message: 'Cleaning project...');
+    _log.stackedOutput(message: 'Cleaning project...');
 
     // Removes `widget_test` file to avoid failing unit tests on created app
     await _fileService.deleteFile(
@@ -122,7 +124,7 @@ class CreateAppCommand extends Command {
       );
     }
 
-    _cLog.stackedOutput(message: 'Project cleaned.');
+    _log.stackedOutput(message: 'Project cleaned.');
   }
 
   /// Replaces configuration file in the project created.

--- a/lib/src/commands/create/create_bottom_sheet_command.dart
+++ b/lib/src/commands/create/create_bottom_sheet_command.dart
@@ -6,6 +6,7 @@ import 'package:stacked_cli/src/constants/message_constants.dart';
 import 'package:stacked_cli/src/locator.dart';
 import 'package:stacked_cli/src/mixins/project_structure_validator_mixin.dart';
 import 'package:stacked_cli/src/services/analytics_service.dart';
+import 'package:stacked_cli/src/services/colorized_log_service.dart';
 import 'package:stacked_cli/src/services/config_service.dart';
 import 'package:stacked_cli/src/services/process_service.dart';
 import 'package:stacked_cli/src/services/pubspec_service.dart';
@@ -13,6 +14,7 @@ import 'package:stacked_cli/src/services/template_service.dart';
 import 'package:stacked_cli/src/templates/template_constants.dart';
 
 class CreateBottomSheetCommand extends Command with ProjectStructureValidator {
+  final _log = locator<ColorizedLogService>();
   final _configService = locator<ConfigService>();
   final _processService = locator<ProcessService>();
   final _pubspecService = locator<PubspecService>();
@@ -53,29 +55,44 @@ class CreateBottomSheetCommand extends Command with ProjectStructureValidator {
       defaultsTo: 'empty',
       help: kCommandHelpCreateBottomSheetTemplate,
     );
+
+    argParser.addOption(
+      ksConfigPath,
+      abbr: 'c',
+      help: kCommandHelpConfigFilePath,
+    );
   }
 
   @override
   Future<void> run() async {
-    final bottomSheetName = argResults!.rest.first;
-    final templateType = argResults![ksTemplateType];
-    unawaited(_analyticsService.createBottomSheetEvent(name: bottomSheetName));
-    final outputPath = argResults!.rest.length > 1 ? argResults!.rest[1] : null;
-    await _configService.loadConfig(path: outputPath);
-    _processService.formattingLineLength = argResults![ksLineLength];
-    await _pubspecService.initialise(workingDirectory: outputPath);
-    await validateStructure(outputPath: outputPath);
+    try {
+      final bottomSheetName = argResults!.rest.first;
+      final templateType = argResults![ksTemplateType];
+      unawaited(
+          _analyticsService.createBottomSheetEvent(name: bottomSheetName));
+      final outputPath =
+          argResults!.rest.length > 1 ? argResults!.rest[1] : null;
+      await _configService.composeAndLoadConfigFile(
+        configFilePath: argResults![ksConfigPath],
+        projectPath: outputPath,
+      );
+      _processService.formattingLineLength = argResults![ksLineLength];
+      await _pubspecService.initialise(workingDirectory: outputPath);
+      await validateStructure(outputPath: outputPath);
 
-    await _templateService.renderTemplate(
-      templateName: name,
-      name: bottomSheetName,
-      outputPath: outputPath,
-      verbose: true,
-      excludeRoute: argResults![ksExcludeRoute],
-      hasModel: argResults![ksModel],
-      templateType: templateType,
-    );
+      await _templateService.renderTemplate(
+        templateName: name,
+        name: bottomSheetName,
+        outputPath: outputPath,
+        verbose: true,
+        excludeRoute: argResults![ksExcludeRoute],
+        hasModel: argResults![ksModel],
+        templateType: templateType,
+      );
 
-    await _processService.runBuildRunner(appName: outputPath);
+      await _processService.runBuildRunner(appName: outputPath);
+    } catch (e) {
+      _log.warn(message: e.toString());
+    }
   }
 }

--- a/lib/src/commands/create/create_dialog_command.dart
+++ b/lib/src/commands/create/create_dialog_command.dart
@@ -6,6 +6,7 @@ import 'package:stacked_cli/src/constants/message_constants.dart';
 import 'package:stacked_cli/src/locator.dart';
 import 'package:stacked_cli/src/mixins/project_structure_validator_mixin.dart';
 import 'package:stacked_cli/src/services/analytics_service.dart';
+import 'package:stacked_cli/src/services/colorized_log_service.dart';
 import 'package:stacked_cli/src/services/config_service.dart';
 import 'package:stacked_cli/src/services/process_service.dart';
 import 'package:stacked_cli/src/services/pubspec_service.dart';
@@ -13,6 +14,7 @@ import 'package:stacked_cli/src/services/template_service.dart';
 import 'package:stacked_cli/src/templates/template_constants.dart';
 
 class CreateDialogCommand extends Command with ProjectStructureValidator {
+  final _log = locator<ColorizedLogService>();
   final _configService = locator<ConfigService>();
   final _processService = locator<ProcessService>();
   final _pubspecService = locator<PubspecService>();
@@ -53,29 +55,43 @@ class CreateDialogCommand extends Command with ProjectStructureValidator {
       defaultsTo: 'empty',
       help: kCommandHelpCreateDialogTemplate,
     );
+
+    argParser.addOption(
+      ksConfigPath,
+      abbr: 'c',
+      help: kCommandHelpConfigFilePath,
+    );
   }
 
   @override
   Future<void> run() async {
-    final dialogName = argResults!.rest.first;
-    final templateType = argResults![ksTemplateType];
-    unawaited(_analyticsService.createDialogEvent(name: dialogName));
-    final outputPath = argResults!.rest.length > 1 ? argResults!.rest[1] : null;
-    await _configService.loadConfig(path: outputPath);
-    _processService.formattingLineLength = argResults![ksLineLength];
-    await _pubspecService.initialise(workingDirectory: outputPath);
-    await validateStructure(outputPath: outputPath);
+    try {
+      final dialogName = argResults!.rest.first;
+      final templateType = argResults![ksTemplateType];
+      unawaited(_analyticsService.createDialogEvent(name: dialogName));
+      final outputPath =
+          argResults!.rest.length > 1 ? argResults!.rest[1] : null;
+      await _configService.composeAndLoadConfigFile(
+        configFilePath: argResults![ksConfigPath],
+        projectPath: outputPath,
+      );
+      _processService.formattingLineLength = argResults![ksLineLength];
+      await _pubspecService.initialise(workingDirectory: outputPath);
+      await validateStructure(outputPath: outputPath);
 
-    await _templateService.renderTemplate(
-      templateName: name,
-      name: dialogName,
-      outputPath: outputPath,
-      verbose: true,
-      excludeRoute: argResults![ksExcludeRoute],
-      hasModel: argResults![ksModel],
-      templateType: templateType,
-    );
+      await _templateService.renderTemplate(
+        templateName: name,
+        name: dialogName,
+        outputPath: outputPath,
+        verbose: true,
+        excludeRoute: argResults![ksExcludeRoute],
+        hasModel: argResults![ksModel],
+        templateType: templateType,
+      );
 
-    await _processService.runBuildRunner(appName: outputPath);
+      await _processService.runBuildRunner(appName: outputPath);
+    } catch (e) {
+      _log.warn(message: e.toString());
+    }
   }
 }

--- a/lib/src/commands/create/create_view_command.dart
+++ b/lib/src/commands/create/create_view_command.dart
@@ -6,6 +6,7 @@ import 'package:stacked_cli/src/constants/message_constants.dart';
 import 'package:stacked_cli/src/locator.dart';
 import 'package:stacked_cli/src/mixins/project_structure_validator_mixin.dart';
 import 'package:stacked_cli/src/services/analytics_service.dart';
+import 'package:stacked_cli/src/services/colorized_log_service.dart';
 import 'package:stacked_cli/src/services/config_service.dart';
 import 'package:stacked_cli/src/services/process_service.dart';
 import 'package:stacked_cli/src/services/pubspec_service.dart';
@@ -13,6 +14,7 @@ import 'package:stacked_cli/src/services/template_service.dart';
 import 'package:stacked_cli/src/templates/template_constants.dart';
 
 class CreateViewCommand extends Command with ProjectStructureValidator {
+  final _log = locator<ColorizedLogService>();
   final _configService = locator<ConfigService>();
   final _processService = locator<ProcessService>();
   final _pubspecService = locator<PubspecService>();
@@ -53,34 +55,48 @@ class CreateViewCommand extends Command with ProjectStructureValidator {
       allowed: ['empty', 'web'],
       help: kCommandHelpCreateViewTemplate,
     );
+
+    argParser.addOption(
+      ksConfigPath,
+      abbr: 'c',
+      help: kCommandHelpConfigFilePath,
+    );
   }
 
   @override
   Future<void> run() async {
-    final viewName = argResults!.rest.first;
-    var templateType = argResults![ksTemplateType] as String?;
-    unawaited(_analyticsService.createViewEvent(name: viewName));
-    final outputPath = argResults!.rest.length > 1 ? argResults!.rest[1] : null;
-    await _configService.loadConfig(path: outputPath);
-    _processService.formattingLineLength = argResults![ksLineLength];
-    await _pubspecService.initialise(workingDirectory: outputPath);
-    await validateStructure(outputPath: outputPath);
+    try {
+      final viewName = argResults!.rest.first;
+      var templateType = argResults![ksTemplateType] as String?;
+      unawaited(_analyticsService.createViewEvent(name: viewName));
+      final outputPath =
+          argResults!.rest.length > 1 ? argResults!.rest[1] : null;
+      await _configService.composeAndLoadConfigFile(
+        configFilePath: argResults![ksConfigPath],
+        projectPath: outputPath,
+      );
+      _processService.formattingLineLength = argResults![ksLineLength];
+      await _pubspecService.initialise(workingDirectory: outputPath);
+      await validateStructure(outputPath: outputPath);
 
-    // Determine which template to use with the following rules:
-    // 1. If the template is supplied we use that template
-    // 2. If the template is null use config web to decide
-    print('templateType:$templateType preferWeb:${_configService.preferWeb}');
-    templateType ??= _configService.preferWeb ? 'web' : 'empty';
+      // Determine which template to use with the following rules:
+      // 1. If the template is supplied we use that template
+      // 2. If the template is null use config web to decide
+      print('templateType:$templateType preferWeb:${_configService.preferWeb}');
+      templateType ??= _configService.preferWeb ? 'web' : 'empty';
 
-    await _templateService.renderTemplate(
-      templateName: name,
-      name: viewName,
-      outputPath: outputPath,
-      verbose: true,
-      excludeRoute: argResults![ksExcludeRoute],
-      useBuilder: argResults![ksV1] ?? _configService.v1,
-      templateType: templateType,
-    );
-    await _processService.runBuildRunner(appName: outputPath);
+      await _templateService.renderTemplate(
+        templateName: name,
+        name: viewName,
+        outputPath: outputPath,
+        verbose: true,
+        excludeRoute: argResults![ksExcludeRoute],
+        useBuilder: argResults![ksV1] ?? _configService.v1,
+        templateType: templateType,
+      );
+      await _processService.runBuildRunner(appName: outputPath);
+    } catch (e) {
+      _log.warn(message: e.toString());
+    }
   }
 }

--- a/lib/src/commands/delete/delete_service_command.dart
+++ b/lib/src/commands/delete/delete_service_command.dart
@@ -41,6 +41,12 @@ class DeleteServiceCommand extends Command with ProjectStructureValidator {
       help: 'The length of the line that is used for formatting',
       valueHelp: '80',
     );
+
+    argParser.addOption(
+      ksConfigPath,
+      abbr: 'c',
+      help: kCommandHelpConfigFilePath,
+    );
   }
 
   @override
@@ -49,7 +55,10 @@ class DeleteServiceCommand extends Command with ProjectStructureValidator {
       name: argResults!.rest.first,
     ));
     final outputPath = argResults!.rest.length > 1 ? argResults!.rest[1] : null;
-    await _configService.loadConfig(path: outputPath);
+    await _configService.composeAndLoadConfigFile(
+      configFilePath: argResults![ksConfigPath],
+      projectPath: outputPath,
+    );
     _processService.formattingLineLength = argResults?[ksLineLength];
     await _pubspecService.initialise(workingDirectory: outputPath);
     await validateStructure(outputPath: outputPath);
@@ -105,8 +114,9 @@ class DeleteServiceCommand extends Command with ProjectStructureValidator {
       outputFolder: outputPath,
     );
     await _fileService.removeSpecificFileLines(
-        filePath: filePath,
-        removedContent: argResults!.rest.first,
-        type: kTemplateNameService);
+      filePath: filePath,
+      removedContent: argResults!.rest.first,
+      type: kTemplateNameService,
+    );
   }
 }

--- a/lib/src/commands/delete/delete_view_commad.dart
+++ b/lib/src/commands/delete/delete_view_commad.dart
@@ -41,13 +41,22 @@ class DeleteViewCommand extends Command with ProjectStructureValidator {
       help: 'The length of the line that is used for formatting',
       valueHelp: '80',
     );
+
+    argParser.addOption(
+      ksConfigPath,
+      abbr: 'c',
+      help: kCommandHelpConfigFilePath,
+    );
   }
 
   @override
   Future<void> run() async {
     unawaited(_analyticsService.deleteViewEvent(name: argResults!.rest.first));
     final outputPath = argResults!.rest.length > 1 ? argResults!.rest[1] : null;
-    await _configService.loadConfig(path: outputPath);
+    await _configService.composeAndLoadConfigFile(
+      configFilePath: argResults![ksConfigPath],
+      projectPath: outputPath,
+    );
     _processService.formattingLineLength = argResults?[ksLineLength];
     await _pubspecService.initialise(workingDirectory: outputPath);
     await validateStructure(outputPath: outputPath);

--- a/lib/src/constants/message_constants.dart
+++ b/lib/src/constants/message_constants.dart
@@ -44,7 +44,7 @@ const String kCommandHelpLineLength =
 const String kCommandHelpCreateAppTemplate =
     'Selects the type of starter template to use when creating a new app. One oriented for mobile first or web first';
 
-const String kCommandHelpCreateAppConfigFile =
+const String kCommandHelpConfigFilePath =
     'Sets the file path for the custom config';
 
 const String kCommandHelpCreateViewTemplate =
@@ -69,7 +69,7 @@ const String kConfigFileNotFound =
     'No configuration file found. Default Stacked values will be used.';
 
 const String kConfigFileNotFoundRetry =
-    'No configuration file found. Please, correct the config path passed as argument.';
+    'No configuration file found. Please, verify the config path passed as argument.';
 
 const String kConfigFileMalformed =
     'Your configuration file is malformed. Double check to make sure you have properly formatted json.';

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -1002,21 +1002,78 @@ class MockConfigService extends _i1.Mock implements _i15.ConfigService {
         returnValueForMissingStub: false,
       ) as bool);
   @override
-  _i6.Future<String?> resolveConfigFile({String? path}) => (super.noSuchMethod(
+  _i6.Future<void> findAndLoadConfigFile({
+    String? configFilePath,
+    String? projectPath,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #findAndLoadConfigFile,
+          [],
+          {
+            #configFilePath: configFilePath,
+            #projectPath: projectPath,
+          },
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+  @override
+  _i6.Future<void> composeAndLoadConfigFile({
+    String? configFilePath,
+    String? projectPath,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #composeAndLoadConfigFile,
+          [],
+          {
+            #configFilePath: configFilePath,
+            #projectPath: projectPath,
+          },
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+  @override
+  _i6.Future<String> resolveConfigFile({
+    String? configFilePath,
+    String? projectPath,
+  }) =>
+      (super.noSuchMethod(
         Invocation.method(
           #resolveConfigFile,
           [],
-          {#path: path},
+          {
+            #configFilePath: configFilePath,
+            #projectPath: projectPath,
+          },
         ),
-        returnValue: _i6.Future<String?>.value(),
-        returnValueForMissingStub: _i6.Future<String?>.value(),
-      ) as _i6.Future<String?>);
+        returnValue: _i6.Future<String>.value(''),
+        returnValueForMissingStub: _i6.Future<String>.value(''),
+      ) as _i6.Future<String>);
   @override
-  _i6.Future<void> loadConfig({String? path}) => (super.noSuchMethod(
+  _i6.Future<String> composeConfigFile({
+    String? configFilePath,
+    String? projectPath,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #composeConfigFile,
+          [],
+          {
+            #configFilePath: configFilePath,
+            #projectPath: projectPath,
+          },
+        ),
+        returnValue: _i6.Future<String>.value(''),
+        returnValueForMissingStub: _i6.Future<String>.value(''),
+      ) as _i6.Future<String>);
+  @override
+  _i6.Future<void> loadConfig(String? configFilePath) => (super.noSuchMethod(
         Invocation.method(
           #loadConfig,
-          [],
-          {#path: path},
+          [configFilePath],
         ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -1002,18 +1002,12 @@ class MockConfigService extends _i1.Mock implements _i15.ConfigService {
         returnValueForMissingStub: false,
       ) as bool);
   @override
-  _i6.Future<void> findAndLoadConfigFile({
-    String? configFilePath,
-    String? projectPath,
-  }) =>
+  _i6.Future<void> findAndLoadConfigFile({String? configFilePath}) =>
       (super.noSuchMethod(
         Invocation.method(
           #findAndLoadConfigFile,
           [],
-          {
-            #configFilePath: configFilePath,
-            #projectPath: projectPath,
-          },
+          {#configFilePath: configFilePath},
         ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),
@@ -1036,18 +1030,12 @@ class MockConfigService extends _i1.Mock implements _i15.ConfigService {
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
   @override
-  _i6.Future<String> resolveConfigFile({
-    String? configFilePath,
-    String? projectPath,
-  }) =>
+  _i6.Future<String> resolveConfigFile({String? configFilePath}) =>
       (super.noSuchMethod(
         Invocation.method(
           #resolveConfigFile,
           [],
-          {
-            #configFilePath: configFilePath,
-            #projectPath: projectPath,
-          },
+          {#configFilePath: configFilePath},
         ),
         returnValue: _i6.Future<String>.value(''),
         returnValueForMissingStub: _i6.Future<String>.value(''),


### PR DESCRIPTION
- Fixed stacked config inside project not used on commands execution
- Added `--config-path` option to all commands where configuration file is needed
- Added verification file exists on `_clean` method before deletion

Fixes https://github.com/Stacked-Org/stacked/issues/912
Fixes https://github.com/Stacked-Org/stacked/issues/960