### PR TITLE
fix: avoid removing multiple dependencies when multiple classes match at the end of the name

### DIFF
--- a/lib/src/services/file_service.dart
+++ b/lib/src/services/file_service.dart
@@ -136,14 +136,14 @@ class FileService {
       );
     }
     List<String> fileLines = await readFileAsLines(filePath: filePath);
-    fileLines.removeWhere((line) => line.contains(recaseName.snakeCase));
-    fileLines.removeWhere((line) => line.contains(recaseName.pascalCase));
+    fileLines.removeWhere((line) => line.contains('/${recaseName.snakeCase}'));
+    fileLines.removeWhere((line) => line.contains(' ${recaseName.pascalCase}'));
     await writeStringFile(
       file: File(filePath),
       fileContent: fileLines.join('\n'),
       type: FileModificationType.Modify,
       verbose: true,
-      verboseMessage: "Removed ${recaseName.pascalCase}$type from $filePath",
+      verboseMessage: "Removed ${recaseName.pascalCase} from $filePath",
     );
   }
 

--- a/lib/src/templates/compiled_template_map.dart
+++ b/lib/src/templates/compiled_template_map.dart
@@ -308,18 +308,21 @@ Map<String, Map<String, StackedTemplate>> kCompiledStackedTemplates = {
           relativeModificationPath: 'lib/app/app.dart',
           modificationIdentifier: '// @stacked-dialog',
           modificationTemplate: '''StackedDialog(classType: {{dialogName}}),''',
-          modificationProblemError: 'The dialog registration should be stored in lib/app/app.dart',
-          modificationName: 'Add \'{{dialogName}}\' dependency to StackedApp annotations file',
+          modificationProblemError:
+              'The dialog registration should be stored in lib/app/app.dart',
+          modificationName:
+              'Add \'{{dialogName}}\' dependency to StackedApp annotations file',
         ),
-        
         ModificationFile(
           relativeModificationPath: 'lib/app/app.dart',
           modificationIdentifier: '// @stacked-import',
-          modificationTemplate: '''import \'package:{{packageName}}/{{{dialogsPath}}}/{{dialogFolderName}}/{{dialogFilename}}\';''',
-          modificationProblemError: 'The dialog registration should be stored in lib/app/app.dart',
+          modificationTemplate:
+              '''import \'package:{{packageName}}/{{{dialogsPath}}}/{{dialogFolderName}}/{{dialogFilename}}\';''',
+          modificationProblemError:
+              'The dialog registration should be stored in lib/app/app.dart',
           modificationName: 'Add import for \'{{dialogName}}\' class',
         ),
-        ],
+      ],
     ),
   },
   'view': {
@@ -347,18 +350,22 @@ Map<String, Map<String, StackedTemplate>> kCompiledStackedTemplates = {
           relativeModificationPath: 'lib/app/app.dart',
           modificationIdentifier: '// @stacked-route',
           modificationTemplate: '''MaterialRoute(page: {{viewName}}),''',
-          modificationProblemError: 'The structure of your stacked application is invalid. The app.dart file should be located in lib/app/',
-          modificationName: 'Add {{viewName}} route where @StackedApp annotation is located',
+          modificationProblemError:
+              'The structure of your stacked application is invalid. The app.dart file should be located in lib/app/',
+          modificationName:
+              'Add {{viewName}} route where @StackedApp annotation is located',
         ),
-        
         ModificationFile(
           relativeModificationPath: 'lib/app/app.dart',
           modificationIdentifier: '// @stacked-import',
-          modificationTemplate: '''import \'package:{{packageName}}/{{{viewImportPath}}}/{{viewFolderName}}/{{viewFileName}}\';''',
-          modificationProblemError: 'The structure of your stacked application is invalid. The app.dart file should be located in lib/app/',
-          modificationName: 'Add {{viewName}} route import where @StackedApp annotation is located',
+          modificationTemplate:
+              '''import \'package:{{packageName}}/{{{viewImportPath}}}/{{viewFolderName}}/{{viewFileName}}\';''',
+          modificationProblemError:
+              'The structure of your stacked application is invalid. The app.dart file should be located in lib/app/',
+          modificationName:
+              'Add {{viewName}} route import where @StackedApp annotation is located',
         ),
-        ],
+      ],
     ),
     'web': StackedTemplate(
       templateFiles: [
@@ -392,18 +399,22 @@ Map<String, Map<String, StackedTemplate>> kCompiledStackedTemplates = {
           relativeModificationPath: 'lib/app/app.dart',
           modificationIdentifier: '// @stacked-route',
           modificationTemplate: '''CustomRoute(page: {{viewName}}),''',
-          modificationProblemError: 'The structure of your stacked application is invalid. The app.dart file should be located in lib/app/',
-          modificationName: 'Add {{viewName}} route where @StackedApp annotation is located',
+          modificationProblemError:
+              'The structure of your stacked application is invalid. The app.dart file should be located in lib/app/',
+          modificationName:
+              'Add {{viewName}} route where @StackedApp annotation is located',
         ),
-        
         ModificationFile(
           relativeModificationPath: 'lib/app/app.dart',
           modificationIdentifier: '// @stacked-import',
-          modificationTemplate: '''import \'package:{{packageName}}/{{{viewImportPath}}}/{{viewFolderName}}/{{viewFileName}}\';''',
-          modificationProblemError: 'The structure of your stacked application is invalid. The app.dart file should be located in lib/app/',
-          modificationName: 'Add {{viewName}} route import where @StackedApp annotation is located',
+          modificationTemplate:
+              '''import \'package:{{packageName}}/{{{viewImportPath}}}/{{viewFolderName}}/{{viewFileName}}\';''',
+          modificationProblemError:
+              'The structure of your stacked application is invalid. The app.dart file should be located in lib/app/',
+          modificationName:
+              'Add {{viewName}} route import where @StackedApp annotation is located',
         ),
-        ],
+      ],
     ),
   },
   'service': {
@@ -422,63 +433,72 @@ Map<String, Map<String, StackedTemplate>> kCompiledStackedTemplates = {
         ModificationFile(
           relativeModificationPath: 'test/helpers/test_helpers.dart',
           modificationIdentifier: '// @stacked-mock-create',
-          modificationTemplate: '''Mock{{serviceName}} getAndRegister{{serviceName}}() { 
+          modificationTemplate:
+              '''Mock{{serviceName}} getAndRegister{{serviceName}}() { 
 _removeRegistrationIfExists<{{serviceName}}>(); 
 final service = Mock{{serviceName}}(); 
 {{locatorName}}.registerSingleton<{{serviceName}}>(service); 
 return service; 
 }''',
-          modificationProblemError: 'The test mocks and helpers should be stored in test/helpers/test_helpers.dart',
+          modificationProblemError:
+              'The test mocks and helpers should be stored in test/helpers/test_helpers.dart',
           modificationName: 'Add {{serviceName}} mock to test helpers',
         ),
-        
         ModificationFile(
           relativeModificationPath: 'lib/app/app.dart',
           modificationIdentifier: '// @stacked-service',
-          modificationTemplate: '''LazySingleton(classType: {{serviceName}}),''',
-          modificationProblemError: 'The service registration should be stored in lib/app/app.dart',
-          modificationName: 'Add {{serviceName}} dependency to StackedApp annotations file',
+          modificationTemplate:
+              '''LazySingleton(classType: {{serviceName}}),''',
+          modificationProblemError:
+              'The service registration should be stored in lib/app/app.dart',
+          modificationName:
+              'Add {{serviceName}} dependency to StackedApp annotations file',
         ),
-        
         ModificationFile(
           relativeModificationPath: 'lib/app/app.dart',
           modificationIdentifier: '// @stacked-import',
-          modificationTemplate: '''import \'package:{{packageName}}/{{{serviceImportPath}}}/{{serviceFilename}}\';''',
-          modificationProblemError: 'The service registration should be stored in lib/app/app.dart',
-          modificationName: 'Add {{serviceName}} import to StackedApp annotations file',
+          modificationTemplate:
+              '''import \'package:{{packageName}}/{{{serviceImportPath}}}/{{serviceFilename}}\';''',
+          modificationProblemError:
+              'The service registration should be stored in lib/app/app.dart',
+          modificationName:
+              'Add {{serviceName}} import to StackedApp annotations file',
         ),
-        
         ModificationFile(
           relativeModificationPath: 'test/helpers/test_helpers.dart',
           modificationIdentifier: '// @stacked-mock-spec',
-          modificationTemplate: '''MockSpec<{{serviceName}}>(onMissingStub: OnMissingStub.returnDefault),''',
-          modificationProblemError: 'The test mocks and helpers should be stored in test/helpers/test_helpers.dart',
+          modificationTemplate:
+              '''MockSpec<{{serviceName}}>(onMissingStub: OnMissingStub.returnDefault),''',
+          modificationProblemError:
+              'The test mocks and helpers should be stored in test/helpers/test_helpers.dart',
           modificationName: 'Create {{serviceName}} mock to test helpers',
         ),
-        
         ModificationFile(
           relativeModificationPath: 'test/helpers/test_helpers.dart',
           modificationIdentifier: '// @stacked-mock-register',
           modificationTemplate: '''getAndRegister{{serviceName}}();''',
-          modificationProblemError: 'The test mocks and helpers should be stored in test/helpers/test_helpers.dart',
+          modificationProblemError:
+              'The test mocks and helpers should be stored in test/helpers/test_helpers.dart',
           modificationName: 'Add {{serviceName}} register to test helpers',
         ),
-        
         ModificationFile(
           relativeModificationPath: 'test/helpers/test_helpers.dart',
           modificationIdentifier: '// @stacked-import',
-          modificationTemplate: '''import \'package:{{packageName}}/{{{serviceImportPath}}}/{{serviceFilename}}\';''',
-          modificationProblemError: 'It seems your test_helpers.dart file is not in test/helpers/test_helpers.dart. Add a stacked.json file and set the path for \'test_helpers_path\' to the folder we can locate your test_helpers.dart file',
+          modificationTemplate:
+              '''import \'package:{{packageName}}/{{{serviceImportPath}}}/{{serviceFilename}}\';''',
+          modificationProblemError:
+              'It seems your test_helpers.dart file is not in test/helpers/test_helpers.dart. Add a stacked.json file and set the path for \'test_helpers_path\' to the folder we can locate your test_helpers.dart file',
           modificationName: 'Add {{serviceName}} import to test helpers',
         ),
-        ],
+      ],
     ),
   },
   'bottom_sheet': {
     'empty': StackedTemplate(
       templateFiles: [
         TemplateFile(
-            relativeOutputPath: kBottomSheetEmptyTemplateGenericSheetModelTestPath,
+            relativeOutputPath:
+                kBottomSheetEmptyTemplateGenericSheetModelTestPath,
             content: kBottomSheetEmptyTemplateGenericSheetModelTestContent,
             fileType: FileType.text),
         TemplateFile(
@@ -486,7 +506,8 @@ return service;
             content: kBottomSheetEmptyTemplateGenericSheetModelContent,
             fileType: FileType.text),
         TemplateFile(
-            relativeOutputPath: kBottomSheetEmptyTemplateGenericSheetUseModelPath,
+            relativeOutputPath:
+                kBottomSheetEmptyTemplateGenericSheetUseModelPath,
             content: kBottomSheetEmptyTemplateGenericSheetUseModelContent,
             fileType: FileType.text),
         TemplateFile(
@@ -498,19 +519,23 @@ return service;
         ModificationFile(
           relativeModificationPath: 'lib/app/app.dart',
           modificationIdentifier: '// @stacked-bottom-sheet',
-          modificationTemplate: '''StackedBottomsheet(classType: {{sheetName}}),''',
-          modificationProblemError: 'The bottom sheet registration should be stored in lib/app/app.dart',
-          modificationName: 'Add \'{{sheetName}}\' dependency to StackedApp annotations file',
+          modificationTemplate:
+              '''StackedBottomsheet(classType: {{sheetName}}),''',
+          modificationProblemError:
+              'The bottom sheet registration should be stored in lib/app/app.dart',
+          modificationName:
+              'Add \'{{sheetName}}\' dependency to StackedApp annotations file',
         ),
-        
         ModificationFile(
           relativeModificationPath: 'lib/app/app.dart',
           modificationIdentifier: '// @stacked-import',
-          modificationTemplate: '''import \'package:{{packageName}}/{{{bottomSheetsPath}}}/{{sheetFolderName}}/{{sheetFilename}}\';''',
-          modificationProblemError: 'The bottom sheet registration should be stored in lib/app/app.dart',
+          modificationTemplate:
+              '''import \'package:{{packageName}}/{{{bottomSheetsPath}}}/{{sheetFolderName}}/{{sheetFilename}}\';''',
+          modificationProblemError:
+              'The bottom sheet registration should be stored in lib/app/app.dart',
           modificationName: 'Add import for \'{{sheetName}}\' class',
         ),
-        ],
+      ],
     ),
   },
 };

--- a/lib/src/templates/compiled_templates.dart
+++ b/lib/src/templates/compiled_templates.dart
@@ -1,11 +1,9 @@
 /// NOTE: This is generated code from the compileTemplates command. Do not modify by hand
 ///       This file should be checked into source control.
 
-
 // -------- StackedJsonStk Template Data ----------
 
-const String kAppWebTemplateStackedJsonStkPath =
-    'stacked.json.stk';
+const String kAppWebTemplateStackedJsonStkPath = 'stacked.json.stk';
 
 const String kAppWebTemplateStackedJsonStkContent = '''
 {
@@ -29,7 +27,6 @@ const String kAppWebTemplateStackedJsonStkContent = '''
 
 // --------------------------------------------------
 
-
 // -------- UnknownViewmodelTest Template Data ----------
 
 const String kAppWebTemplateUnknownViewmodelTestPath =
@@ -50,7 +47,6 @@ void main() {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- HomeViewmodelTest Template Data ----------
 
@@ -103,7 +99,6 @@ void main() {
 
 // --------------------------------------------------
 
-
 // -------- NoticeSheetModelTest Template Data ----------
 
 const String kAppWebTemplateNoticeSheetModelTestPath =
@@ -126,7 +121,6 @@ void main() {
 
 // --------------------------------------------------
 
-
 // -------- InfoAlertDialogModelTest Template Data ----------
 
 const String kAppWebTemplateInfoAlertDialogModelTestPath =
@@ -148,7 +142,6 @@ void main() {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- TestHelpers Template Data ----------
 
@@ -239,11 +232,9 @@ void _removeRegistrationIfExists<T extends Object>() {
 
 // --------------------------------------------------
 
-
 // -------- BuildYamlStk Template Data ----------
 
-const String kAppWebTemplateBuildYamlStkPath =
-    'build.yaml.stk';
+const String kAppWebTemplateBuildYamlStkPath = 'build.yaml.stk';
 
 const String kAppWebTemplateBuildYamlStkContent = '''
 targets:
@@ -256,11 +247,9 @@ targets:
 
 // --------------------------------------------------
 
-
 // -------- MainIconPngStk Template Data ----------
 
-const String kAppWebTemplateMainIconPngStkPath =
-    'web/main-icon.png.stk';
+const String kAppWebTemplateMainIconPngStkPath = 'web/main-icon.png.stk';
 
 const String kAppWebTemplateMainIconPngStkContent = '''
 iVBORw0KGgoAAAANSUhEUgAAALMAAACzCAYAAADCFC3zAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAN5SURBVHgB7daLjVNBDEDRF0QjVEIrdMLSAS3RyZZAByGWdqUQ5Z/5eGbOkSw3cC152wAAAAAAAAAAAAAAAACAjHZbYfuDDW77tdvt3raCvmzQXvGQg5hprUrIQcy0VC3kIGZaqRpyEDMtVA85iJnamoQcxExNzUIOYqaWpiEHMVND85CDmCmtS8hBzJTULeQgZkrpGnIQMyV0DzmImVelCDmImVekCTmImWelCjmImWekCzmImUelDDmImUekDTmImXulDjmImXukDzmImVuGCDmImWuGCTmImUuGCjmImXOGCzmImVNDhhzEzLFhQw5i5tPQIQcxE4YPOYiZKUIOYl7bNCEHMa9rqpCDmNc0XchBzOuZMuQg5rVMG3IQ8zqmDjmIeQ3ThxzEPL8lQg5intsyIQcxz2upkIOY57RcyEHM81ky5CDmuSwbchDzPJYOOYh5DsuHHMQ8PiF/EPPYhHxEzOMS8gkxj0nIZ4h5PEK+QMxjEfIVYh6HkG8Q8xiEfAcx5yfkO4k5NyE/QMx5CflBYs5JyE8Qcz5CfpKYcxHyC8Sch5BfJOYchFyAmPsTciFi7kvIBYm5HyEXJuY+hFyBmNsTciVibkvIFYm5HSFXttsK2+/3bxunvh/mz8axv4fj/r0VVDxm/nc47p+H9bZx6v0Q87etIG9GRUJuS8yVCLk9MVcg5D7EXJiQ+xFzQULuS8yFCLk/MRcg5BzE/CIh5yHmFwg5FzE/Scj5iPkJQs5JzA8Scl5ifoCQcxPznYScn5jvIOQxiPkGIY9DzFcIeSxivkDI4xHzGUIek5hPCHlcYj4i5LGJ+YOQxyfmTcizWD5mIc9j6ZiFPJdlYxbyfJaMWchzWi5mIc9rqZiFPLdlYhby/JaIWchrmD5mIa9j6piFvJZpYxbyeqaMWchrmi5mIa9rqpiFvLZpYhYyU8QsZMLwMQuZT0PHLGSODRuzkDk1ZMxC5pzhYhYylwwVs5C5ZpiYhcwtQ8QsZO6RPmYhc6/UMQuZR6SNWcg8KmXMQuYZ6WIWMs9KFbOQeUWamIXMq1LELGRK6B6zkCmla8xCpqRuMQuZ0rrELGRqaB6zkKmlacxCpqZmMQuZ2prELGRaqB6zkGmlasxCpqVqMQuZ1qrELGR6+LoVdgj5x2HFvG9w2fsGAAAAAAAAAAAAAAAAACzhH8sFZqawpyetAAAAAElFTkSuQmCC
@@ -268,11 +257,9 @@ iVBORw0KGgoAAAANSUhEUgAAALMAAACzCAYAAADCFC3zAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNS
 
 // --------------------------------------------------
 
-
 // -------- IndexHtmlStk Template Data ----------
 
-const String kAppWebTemplateIndexHtmlStkPath =
-    'web/index.html.stk';
+const String kAppWebTemplateIndexHtmlStkPath = 'web/index.html.stk';
 
 const String kAppWebTemplateIndexHtmlStkContent = '''
 <!DOCTYPE html>
@@ -450,11 +437,9 @@ const String kAppWebTemplateIndexHtmlStkContent = '''
 
 // --------------------------------------------------
 
-
 // -------- FaviconPngStk Template Data ----------
 
-const String kAppWebTemplateFaviconPngStkPath =
-    'web/favicon.png.stk';
+const String kAppWebTemplateFaviconPngStkPath = 'web/favicon.png.stk';
 
 const String kAppWebTemplateFaviconPngStkContent = '''
 iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAHaSURBVHgBpVTNasJAEN7dxLQl+FNEFBRR8VCQgo+gryCkh9499CnUg/gMvo3eFWw9eBLS4sWT2oOHRLOdWWLYxkRT+8GS3cnkm28mM0tIMOhpwzmn7plKdurawz9EdLtdNhqNWKvVekyn0ynLsghjTPg4jsNt26a6rnO09/v9r2Qy6UwmkwOlwoX7yZVqtWqA07v78uqKx+NmsVhsw179Jc4wDKVcLrejEvkXCHlBDlmdlkgkPm8lhKw+arWahipRKikUCspqtSqe2FOpFKnX6+QSZrMZ2W63Yr/b7Z6htshl45kOh8MnOWKj0eCXAD8vSKmOf54ho6qqnEREr9fDbjizZzIZikBCut/v6X/IENBeQikSck3TrnFdJJMghJ3V0L86nc5ZHbHOsk82m9WFUCTEzg8DkEVRhpOE6jhD57CUo5IR4tVQpMyCUg5KM0LKorH5crn8lqNhY4/HY9JsNkMVYWPLWK/XXutRmJQHGPQ5uXH0cGxLpdK9SNeVe8jlcgNyI2CWB6ZpHjwDjgxGyOfzb3+5JIBoXqlUXuG2uSOnHpQCUSi0slgs7qCNVAwCEHXZbDZYV+8sZpYxJxaLHaFc1nQ6PYLZCcsAy6BIT0U6eza83X2CBH4AHNJFlWlQookAAAAASUVORK5CYII=
@@ -462,11 +447,9 @@ iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNS
 
 // --------------------------------------------------
 
-
 // -------- READMEMdStk Template Data ----------
 
-const String kAppWebTemplateREADMEMdStkPath =
-    'README.md.stk';
+const String kAppWebTemplateREADMEMdStkPath = 'README.md.stk';
 
 const String kAppWebTemplateREADMEMdStkContent = '''
 # {{packageName}}
@@ -476,11 +459,9 @@ const String kAppWebTemplateREADMEMdStkContent = '''
 
 // --------------------------------------------------
 
-
 // -------- Main Template Data ----------
 
-const String kAppWebTemplateMainPath =
-    'lib/main.dart.stk';
+const String kAppWebTemplateMainPath = 'lib/main.dart.stk';
 
 const String kAppWebTemplateMainContent = '''
 import 'package:flutter/material.dart';
@@ -522,7 +503,6 @@ class MainApp extends StatelessWidget {
 
 // --------------------------------------------------
 
-
 // -------- AppConstants Template Data ----------
 
 const String kAppWebTemplateAppConstantsPath =
@@ -539,11 +519,9 @@ const double kdDesktopMaxContentHeight = 750;
 
 // --------------------------------------------------
 
-
 // -------- UiHelpers Template Data ----------
 
-const String kAppWebTemplateUiHelpersPath =
-    'lib/ui/common/ui_helpers.dart.stk';
+const String kAppWebTemplateUiHelpersPath = 'lib/ui/common/ui_helpers.dart.stk';
 
 const String kAppWebTemplateUiHelpersContent = '''
 import 'dart:math';
@@ -629,7 +607,6 @@ double getResponsiveFontSize(BuildContext context,
 
 // --------------------------------------------------
 
-
 // -------- AppStrings Template Data ----------
 
 const String kAppWebTemplateAppStringsPath =
@@ -644,11 +621,9 @@ const String ksHomeBottomSheetDescription =
 
 // --------------------------------------------------
 
-
 // -------- AppColors Template Data ----------
 
-const String kAppWebTemplateAppColorsPath =
-    'lib/ui/common/app_colors.dart.stk';
+const String kAppWebTemplateAppColorsPath = 'lib/ui/common/app_colors.dart.stk';
 
 const String kAppWebTemplateAppColorsContent = '''
 import 'package:flutter/material.dart';
@@ -667,7 +642,6 @@ const Color kcBackgroundColor = kcDarkGreyColor;
 
 // --------------------------------------------------
 
-
 // -------- NoticeSheetModel Template Data ----------
 
 const String kAppWebTemplateNoticeSheetModelPath =
@@ -681,7 +655,6 @@ class NoticeSheetModel extends BaseViewModel {}
 ''';
 
 // --------------------------------------------------
-
 
 // -------- NoticeSheet Template Data ----------
 
@@ -751,7 +724,6 @@ class NoticeSheet extends StackedView<NoticeSheetModel> {
 
 // --------------------------------------------------
 
-
 // -------- InfoAlertDialogModel Template Data ----------
 
 const String kAppWebTemplateInfoAlertDialogModelPath =
@@ -765,7 +737,6 @@ class InfoAlertDialogModel extends BaseViewModel {}
 ''';
 
 // --------------------------------------------------
-
 
 // -------- InfoAlertDialog Template Data ----------
 
@@ -886,7 +857,6 @@ class InfoAlertDialog extends StackedView<InfoAlertDialogModel> {
 
 // --------------------------------------------------
 
-
 // -------- HomeViewDesktop Template Data ----------
 
 const String kAppWebTemplateHomeViewDesktopPath =
@@ -972,7 +942,6 @@ class HomeViewDesktop extends ViewModelWidget<HomeViewModel> {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- HomeViewMobile Template Data ----------
 
@@ -1060,7 +1029,6 @@ class HomeViewMobile extends ViewModelWidget<HomeViewModel> {
 
 // --------------------------------------------------
 
-
 // -------- HomeView Template Data ----------
 
 const String kAppWebTemplateHomeViewPath =
@@ -1102,7 +1070,6 @@ class HomeView extends StackedView<HomeViewModel> {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- HomeViewmodel Template Data ----------
 
@@ -1150,7 +1117,6 @@ class HomeViewModel extends BaseViewModel {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- HomeViewTablet Template Data ----------
 
@@ -1238,7 +1204,6 @@ class HomeViewTablet extends ViewModelWidget<HomeViewModel> {
 
 // --------------------------------------------------
 
-
 // -------- UnknownView Template Data ----------
 
 const String kAppWebTemplateUnknownViewPath =
@@ -1280,7 +1245,6 @@ class UnknownView extends StackedView<UnknownViewModel> {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- UnknownViewDesktop Template Data ----------
 
@@ -1337,7 +1301,6 @@ class UnknownViewDesktop extends ViewModelWidget<UnknownViewModel> {
 
 // --------------------------------------------------
 
-
 // -------- UnknownViewTablet Template Data ----------
 
 const String kAppWebTemplateUnknownViewTabletPath =
@@ -1393,7 +1356,6 @@ class UnknownViewTablet extends ViewModelWidget<UnknownViewModel> {
 
 // --------------------------------------------------
 
-
 // -------- UnknownViewmodel Template Data ----------
 
 const String kAppWebTemplateUnknownViewmodelPath =
@@ -1407,7 +1369,6 @@ class UnknownViewModel extends BaseViewModel {}
 ''';
 
 // --------------------------------------------------
-
 
 // -------- UnknownViewMobile Template Data ----------
 
@@ -1463,7 +1424,6 @@ class UnknownViewMobile extends ViewModelWidget<UnknownViewModel> {
 
 // --------------------------------------------------
 
-
 // -------- StartupViewmodel Template Data ----------
 
 const String kAppWebTemplateStartupViewmodelPath =
@@ -1490,7 +1450,6 @@ class StartupViewModel extends BaseViewModel {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- StartupView Template Data ----------
 
@@ -1558,7 +1517,6 @@ class StartupView extends StackedView<StartupViewModel> {
 
 // --------------------------------------------------
 
-
 // -------- ScaleOnHover Template Data ----------
 
 const String kAppWebTemplateScaleOnHoverPath =
@@ -1606,7 +1564,6 @@ class _ScaleOnHoverState extends State<ScaleOnHover> {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- TranslateOnHover Template Data ----------
 
@@ -1664,11 +1621,9 @@ class _TranslateOnHoverState extends State<TranslateOnHover> {
 
 // --------------------------------------------------
 
-
 // -------- App Template Data ----------
 
-const String kAppWebTemplateAppPath =
-    'lib/app/app.dart.stk';
+const String kAppWebTemplateAppPath = 'lib/app/app.dart.stk';
 
 const String kAppWebTemplateAppContent = '''
 import 'package:{{packageName}}/{{{bottomSheetsPath}}}/notice/notice_sheet.dart';
@@ -1711,7 +1666,6 @@ class App {}
 ''';
 
 // --------------------------------------------------
-
 
 // -------- HoverExtensions Template Data ----------
 
@@ -1767,11 +1721,9 @@ extension HoverExtensions on Widget {
 
 // --------------------------------------------------
 
-
 // -------- PubspecYamlStk Template Data ----------
 
-const String kAppWebTemplatePubspecYamlStkPath =
-    'pubspec.yaml.stk';
+const String kAppWebTemplatePubspecYamlStkPath = 'pubspec.yaml.stk';
 
 const String kAppWebTemplatePubspecYamlStkContent = '''
 name: {{packageName}}
@@ -1806,11 +1758,9 @@ flutter:
 
 // --------------------------------------------------
 
-
 // -------- SettingsJsonStk Template Data ----------
 
-const String kAppWebTemplateSettingsJsonStkPath =
-    '.vscode/settings.json.stk';
+const String kAppWebTemplateSettingsJsonStkPath = '.vscode/settings.json.stk';
 
 const String kAppWebTemplateSettingsJsonStkContent = '''
 {
@@ -1824,11 +1774,9 @@ const String kAppWebTemplateSettingsJsonStkContent = '''
 
 // --------------------------------------------------
 
-
 // -------- StackedJsonStk Template Data ----------
 
-const String kAppMobileTemplateStackedJsonStkPath =
-    'stacked.json.stk';
+const String kAppMobileTemplateStackedJsonStkPath = 'stacked.json.stk';
 
 const String kAppMobileTemplateStackedJsonStkContent = '''
 {
@@ -1851,7 +1799,6 @@ const String kAppMobileTemplateStackedJsonStkContent = '''
 ''';
 
 // --------------------------------------------------
-
 
 // -------- HomeViewmodelTest Template Data ----------
 
@@ -1904,7 +1851,6 @@ void main() {
 
 // --------------------------------------------------
 
-
 // -------- NoticeSheetModelTest Template Data ----------
 
 const String kAppMobileTemplateNoticeSheetModelTestPath =
@@ -1927,7 +1873,6 @@ void main() {
 
 // --------------------------------------------------
 
-
 // -------- InfoAlertDialogModelTest Template Data ----------
 
 const String kAppMobileTemplateInfoAlertDialogModelTestPath =
@@ -1949,7 +1894,6 @@ void main() {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- TestHelpers Template Data ----------
 
@@ -2040,11 +1984,9 @@ void _removeRegistrationIfExists<T extends Object>() {
 
 // --------------------------------------------------
 
-
 // -------- READMEMdStk Template Data ----------
 
-const String kAppMobileTemplateREADMEMdStkPath =
-    'README.md.stk';
+const String kAppMobileTemplateREADMEMdStkPath = 'README.md.stk';
 
 const String kAppMobileTemplateREADMEMdStkContent = '''
 # {{packageName}}
@@ -2054,11 +1996,9 @@ const String kAppMobileTemplateREADMEMdStkContent = '''
 
 // --------------------------------------------------
 
-
 // -------- Main Template Data ----------
 
-const String kAppMobileTemplateMainPath =
-    'lib/main.dart.stk';
+const String kAppMobileTemplateMainPath = 'lib/main.dart.stk';
 
 const String kAppMobileTemplateMainContent = '''
 import 'package:flutter/material.dart';
@@ -2095,7 +2035,6 @@ class MainApp extends StatelessWidget {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- UiHelpers Template Data ----------
 
@@ -2186,7 +2125,6 @@ double getResponsiveFontSize(BuildContext context,
 
 // --------------------------------------------------
 
-
 // -------- AppStrings Template Data ----------
 
 const String kAppMobileTemplateAppStringsPath =
@@ -2200,7 +2138,6 @@ const String ksHomeBottomSheetDescription =
 ''';
 
 // --------------------------------------------------
-
 
 // -------- AppColors Template Data ----------
 
@@ -2222,7 +2159,6 @@ const Color kcBackgroundColor = kcDarkGreyColor;
 
 // --------------------------------------------------
 
-
 // -------- NoticeSheetModel Template Data ----------
 
 const String kAppMobileTemplateNoticeSheetModelPath =
@@ -2236,7 +2172,6 @@ class NoticeSheetModel extends BaseViewModel {}
 ''';
 
 // --------------------------------------------------
-
 
 // -------- NoticeSheet Template Data ----------
 
@@ -2306,7 +2241,6 @@ class NoticeSheet extends StackedView<NoticeSheetModel> {
 
 // --------------------------------------------------
 
-
 // -------- InfoAlertDialogModel Template Data ----------
 
 const String kAppMobileTemplateInfoAlertDialogModelPath =
@@ -2320,7 +2254,6 @@ class InfoAlertDialogModel extends BaseViewModel {}
 ''';
 
 // --------------------------------------------------
-
 
 // -------- InfoAlertDialog Template Data ----------
 
@@ -2441,7 +2374,6 @@ class InfoAlertDialog extends StackedView<InfoAlertDialogModel> {
 
 // --------------------------------------------------
 
-
 // -------- HomeViewV1 Template Data ----------
 
 const String kAppMobileTemplateHomeViewV1Path =
@@ -2529,7 +2461,6 @@ class HomeView extends StatelessWidget {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- HomeView Template Data ----------
 
@@ -2626,7 +2557,6 @@ class HomeView extends StackedView<HomeViewModel> {
 
 // --------------------------------------------------
 
-
 // -------- HomeViewmodel Template Data ----------
 
 const String kAppMobileTemplateHomeViewmodelPath =
@@ -2674,7 +2604,6 @@ class HomeViewModel extends BaseViewModel {
 
 // --------------------------------------------------
 
-
 // -------- StartupViewmodel Template Data ----------
 
 const String kAppMobileTemplateStartupViewmodelPath =
@@ -2703,7 +2632,6 @@ class StartupViewModel extends BaseViewModel {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- StartupViewV1 Template Data ----------
 
@@ -2769,7 +2697,6 @@ class StartupView extends StatelessWidget {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- StartupView Template Data ----------
 
@@ -2837,11 +2764,9 @@ class StartupView extends StackedView<StartupViewModel> {
 
 // --------------------------------------------------
 
-
 // -------- App Template Data ----------
 
-const String kAppMobileTemplateAppPath =
-    'lib/app/app.dart.stk';
+const String kAppMobileTemplateAppPath = 'lib/app/app.dart.stk';
 
 const String kAppMobileTemplateAppContent = '''
 import 'package:{{packageName}}/{{{bottomSheetsPath}}}/notice/notice_sheet.dart';
@@ -2879,11 +2804,9 @@ class App {}
 
 // --------------------------------------------------
 
-
 // -------- PubspecYamlStk Template Data ----------
 
-const String kAppMobileTemplatePubspecYamlStkPath =
-    'pubspec.yaml.stk';
+const String kAppMobileTemplatePubspecYamlStkPath = 'pubspec.yaml.stk';
 
 const String kAppMobileTemplatePubspecYamlStkContent = '''
 name: {{packageName}}
@@ -2915,7 +2838,6 @@ flutter:
 
 // --------------------------------------------------
 
-
 // -------- SettingsJsonStk Template Data ----------
 
 const String kAppMobileTemplateSettingsJsonStkPath =
@@ -2932,7 +2854,6 @@ const String kAppMobileTemplateSettingsJsonStkContent = '''
 ''';
 
 // --------------------------------------------------
-
 
 // -------- GenericModelTest Template Data ----------
 
@@ -2955,7 +2876,6 @@ void main() {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- GenericUseModel Template Data ----------
 
@@ -2989,7 +2909,6 @@ class {{widgetName}} extends StackedView<{{widgetModelName}}> {
 
 // --------------------------------------------------
 
-
 // -------- Generic Template Data ----------
 
 const String kWidgetEmptyTemplateGenericPath =
@@ -3011,7 +2930,6 @@ class {{widgetName}} extends StatelessWidget {
 
 // --------------------------------------------------
 
-
 // -------- GenericModel Template Data ----------
 
 const String kWidgetEmptyTemplateGenericModelPath =
@@ -3024,7 +2942,6 @@ class {{widgetModelName}} extends BaseViewModel {}
 ''';
 
 // --------------------------------------------------
-
 
 // -------- GenericDialogModelTest Template Data ----------
 
@@ -3048,7 +2965,6 @@ void main() {
 
 // --------------------------------------------------
 
-
 // -------- GenericDialogModel Template Data ----------
 
 const String kDialogEmptyTemplateGenericDialogModelPath =
@@ -3062,7 +2978,6 @@ class {{dialogModelName}} extends BaseViewModel {}
 ''';
 
 // --------------------------------------------------
-
 
 // -------- GenericDialogUseModel Template Data ----------
 
@@ -3184,7 +3099,6 @@ class {{dialogName}} extends StackedView<{{dialogModelName}}> {
 
 // --------------------------------------------------
 
-
 // -------- GenericDialog Template Data ----------
 
 const String kDialogEmptyTemplateGenericDialogPath =
@@ -3294,7 +3208,6 @@ class {{dialogName}} extends StatelessWidget {
 
 // --------------------------------------------------
 
-
 // -------- GenericViewmodelTest Template Data ----------
 
 const String kViewEmptyTemplateGenericViewmodelTestPath =
@@ -3317,7 +3230,6 @@ void main() {
 
 // --------------------------------------------------
 
-
 // -------- GenericViewmodel Template Data ----------
 
 const String kViewEmptyTemplateGenericViewmodelPath =
@@ -3330,7 +3242,6 @@ class {{viewModelName}} extends BaseViewModel {}
 ''';
 
 // --------------------------------------------------
-
 
 // -------- GenericView Template Data ----------
 
@@ -3369,7 +3280,6 @@ class {{viewName}} extends StackedView<{{viewModelName}}> {
 
 // --------------------------------------------------
 
-
 // -------- GenericViewV1 Template Data ----------
 
 const String kViewEmptyTemplateGenericViewV1Path =
@@ -3401,7 +3311,6 @@ class {{viewName}} extends StatelessWidget {
 
 // --------------------------------------------------
 
-
 // -------- GenericViewmodelTest Template Data ----------
 
 const String kViewWebTemplateGenericViewmodelTestPath =
@@ -3424,7 +3333,6 @@ void main() {
 
 // --------------------------------------------------
 
-
 // -------- GenericViewmodel Template Data ----------
 
 const String kViewWebTemplateGenericViewmodelPath =
@@ -3438,7 +3346,6 @@ class {{viewModelName}} extends BaseViewModel {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- GenericViewMobile Template Data ----------
 
@@ -3474,7 +3381,6 @@ class {{viewName}}Mobile extends ViewModelWidget<{{viewModelName}}> {
 
 // --------------------------------------------------
 
-
 // -------- GenericViewTablet Template Data ----------
 
 const String kViewWebTemplateGenericViewTabletPath =
@@ -3508,7 +3414,6 @@ class {{viewName}}Tablet extends ViewModelWidget<{{viewModelName}}> {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- GenericView Template Data ----------
 
@@ -3552,7 +3457,6 @@ class {{viewName}} extends StackedView<{{viewModelName}}> {
 
 // --------------------------------------------------
 
-
 // -------- GenericViewDesktop Template Data ----------
 
 const String kViewWebTemplateGenericViewDesktopPath =
@@ -3587,7 +3491,6 @@ class {{viewName}}Desktop extends ViewModelWidget<{{viewModelName}}> {
 
 // --------------------------------------------------
 
-
 // -------- GenericServiceTest Template Data ----------
 
 const String kServiceEmptyTemplateGenericServiceTestPath =
@@ -3610,7 +3513,6 @@ void main() {
 
 // --------------------------------------------------
 
-
 // -------- GenericService Template Data ----------
 
 const String kServiceEmptyTemplateGenericServicePath =
@@ -3623,7 +3525,6 @@ class {{serviceName}} {
 ''';
 
 // --------------------------------------------------
-
 
 // -------- GenericSheetModelTest Template Data ----------
 
@@ -3647,7 +3548,6 @@ void main() {
 
 // --------------------------------------------------
 
-
 // -------- GenericSheetModel Template Data ----------
 
 const String kBottomSheetEmptyTemplateGenericSheetModelPath =
@@ -3661,7 +3561,6 @@ class {{sheetModelName}} extends BaseViewModel {}
 ''';
 
 // --------------------------------------------------
-
 
 // -------- GenericSheetUseModel Template Data ----------
 
@@ -3733,7 +3632,6 @@ class {{sheetName}} extends StackedView<{{sheetModelName}}> {
 
 // --------------------------------------------------
 
-
 // -------- GenericSheet Template Data ----------
 
 const String kBottomSheetEmptyTemplateGenericSheetPath =
@@ -3792,4 +3690,3 @@ class {{sheetName}} extends StatelessWidget {
 ''';
 
 // --------------------------------------------------
-

--- a/test/helpers/test_helpers.mocks.dart
+++ b/test/helpers/test_helpers.mocks.dart
@@ -1377,6 +1377,17 @@ class MockAnalyticsService extends _i1.Mock implements _i17.AnalyticsService {
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
   @override
+  _i6.Future<void> deleteDialogEvent({required String? name}) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteDialogEvent,
+          [],
+          {#name: name},
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+  @override
   _i6.Future<void> generateCodeEvent() => (super.noSuchMethod(
         Invocation.method(
           #generateCodeEvent,


### PR DESCRIPTION
Remove lines only for the exact class, not for all the similar classes which matches the target class.

For example, this avoid to delete `SmartErrorDialog` and `ErrorDialog` on the same execution because both classes ended with `ErrorDialog`. So, before the fix, if I run the following command

```shell
stacked delete dialog error
```

was going to delete any dialog which ends with ErrorDialog, in the case presented, ErrorDialog and SmartErrorDialog.