### PR TITLE
feat: Add viewname on view generation

### DIFF
--- a/lib/src/templates/view/empty/lib/ui/views/generic/generic_view.dart.stk
+++ b/lib/src/templates/view/empty/lib/ui/views/generic/generic_view.dart.stk
@@ -16,6 +16,7 @@ class {{viewName}} extends StackedView<{{viewModelName}}> {
       backgroundColor: Theme.of(context).colorScheme.background,
       body: Container(
         padding: const EdgeInsets.only(left: 25.0, right: 25.0),
+        child: const Center(child: Text("{{viewName}}")),
       ),
     );
   }

--- a/lib/src/templates/view/web/lib/ui/views/generic/generic_view.desktop.dart.stk
+++ b/lib/src/templates/view/web/lib/ui/views/generic/generic_view.desktop.dart.stk
@@ -11,7 +11,7 @@ class {{viewName}}Desktop extends ViewModelWidget<{{viewModelName}}> {
     return const Scaffold(
       body: Center(
         child: Text(
-          'Hello, DESKTOP UI!',
+          'Hello, DESKTOP UI - {{viewName}}!',
           style: TextStyle(
             fontSize: 35,
             fontWeight: FontWeight.w900,

--- a/lib/src/templates/view/web/lib/ui/views/generic/generic_view.mobile.dart.stk
+++ b/lib/src/templates/view/web/lib/ui/views/generic/generic_view.mobile.dart.stk
@@ -11,7 +11,7 @@ class {{viewName}}Mobile extends ViewModelWidget<{{viewModelName}}> {
     return const Scaffold(
       body: Center(
         child: Text(
-          'Hello, MOBILE UI!',
+          'Hello, MOBILE UI - {{viewName}}!',
           style: TextStyle(
             fontSize: 35,
             fontWeight: FontWeight.w900,

--- a/lib/src/templates/view/web/lib/ui/views/generic/generic_view.tablet.dart.stk
+++ b/lib/src/templates/view/web/lib/ui/views/generic/generic_view.tablet.dart.stk
@@ -11,7 +11,7 @@ class {{viewName}}Tablet extends ViewModelWidget<{{viewModelName}}> {
     return const Scaffold(
       body: Center(
         child: Text(
-          'Hello, TABLET UI!',
+          'Hello, TABLET UI - {{viewName}}!',
           style: TextStyle(
             fontSize: 35,
             fontWeight: FontWeight.w900,


### PR DESCRIPTION
Hello Stacked Team,

The CLI is really great for very quickly creating all the screens of an application to start or make an MVP. 

Unfortunately, I find that there is a little something missing: display by default the name of the view that we have just generated: just with this small change, it makes things much clearer when we build the flow of the application and link all the screens without even having to add content everywhere!

What do you think ?