### PR TITLE
feat: add delete bottom_sheet command

### DIFF
--- a/lib/src/commands/delete/delete_bottomsheet_command.dart
+++ b/lib/src/commands/delete/delete_bottomsheet_command.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:stacked_cli/src/constants/command_constants.dart';
+import 'package:stacked_cli/src/constants/message_constants.dart';
+import 'package:stacked_cli/src/locator.dart';
+import 'package:stacked_cli/src/mixins/project_structure_validator_mixin.dart';
+import 'package:stacked_cli/src/services/colorized_log_service.dart';
+import 'package:stacked_cli/src/services/config_service.dart';
+import 'package:stacked_cli/src/services/file_service.dart';
+import 'package:stacked_cli/src/services/posthog_service.dart';
+import 'package:stacked_cli/src/services/process_service.dart';
+import 'package:stacked_cli/src/services/pubspec_service.dart';
+import 'package:stacked_cli/src/services/template_service.dart';
+import 'package:stacked_cli/src/templates/compiled_templates.dart';
+import 'package:stacked_cli/src/templates/template_constants.dart';
+
+class DeleteBottomsheetCommand extends Command with ProjectStructureValidator {
+  final _configService = locator<ConfigService>();
+  final _fileService = locator<FileService>();
+  final _log = locator<ColorizedLogService>();
+  final _processService = locator<ProcessService>();
+  final _pubspecService = locator<PubspecService>();
+  final _templateService = locator<TemplateService>();
+  final _analyticsService = locator<PosthogService>();
+
+  @override
+  String get description =>
+      'Deletes a bottomsheet with all associated files and makes necessary code changes for deleting a bottomsheet.';
+
+  @override
+  String get name => kTemplateNameBottomSheet;
+
+  DeleteBottomsheetCommand() {
+    argParser
+      ..addFlag(
+        ksExcludeRoute,
+        defaultsTo: false,
+        help: kCommandHelpExcludeRoute,
+      )
+      ..addOption(
+        ksConfigPath,
+        abbr: 'c',
+        help: kCommandHelpConfigFilePath,
+      )
+      ..addOption(
+        ksLineLength,
+        abbr: 'l',
+        help: kCommandHelpLineLength,
+        valueHelp: '80',
+      );
+  }
+
+  @override
+  Future<void> run() async {
+    try {
+      final workingDirectory =
+          argResults!.rest.length > 1 ? argResults!.rest[1] : null;
+      final bottomsheetName = argResults!.rest.first;
+      await _configService.composeAndLoadConfigFile(
+        configFilePath: argResults![ksConfigPath],
+        projectPath: workingDirectory,
+      );
+      _processService.formattingLineLength = argResults?[ksLineLength];
+      await _pubspecService.initialise(workingDirectory: workingDirectory);
+
+      await validateStructure(outputPath: workingDirectory);
+      await _deletebottomsheet(
+          outputPath: workingDirectory, bottomsheetName: bottomsheetName);
+      await _removebottomsheetFromDependency(
+          outputPath: workingDirectory, bottomsheetName: bottomsheetName);
+      await _processService.runBuildRunner(workingDirectory: workingDirectory);
+      await _analyticsService.deleteBottomsheetEvent(
+        name: argResults!.rest.first,
+        arguments: argResults!.arguments,
+      );
+    } on PathNotFoundException catch (e) {
+      _log.error(message: e.toString());
+      unawaited(_analyticsService.logExceptionEvent(
+        runtimeType: e.runtimeType.toString(),
+        message: e.toString(),
+      ));
+    } catch (e, s) {
+      _log.error(message: e.toString());
+      unawaited(_analyticsService.logExceptionEvent(
+        runtimeType: e.runtimeType.toString(),
+        message: e.toString(),
+        stackTrace: s.toString(),
+      ));
+    }
+  }
+
+  /// It deletes the bottomsheet files
+  ///
+  /// Args:
+  ///
+  ///  `outputPath` (String): The path to the output folder.
+  ///
+  ///  `bottomsheetName` (String): The name of the bottomsheet.
+  Future<void> _deletebottomsheet(
+      {String? outputPath, required String bottomsheetName}) async {
+    /// Deleting the bottomsheet folder.
+    String directoryPath = _templateService.getTemplateOutputPath(
+      inputTemplatePath: 'lib/ui/bottom_sheets/generic',
+      name: bottomsheetName,
+      outputFolder: outputPath,
+    );
+    await _fileService.deleteFolder(directoryPath: directoryPath);
+
+    //Delete test file for bottomsheet
+    final filePath = _templateService.getTemplateOutputPath(
+      inputTemplatePath: kBottomSheetEmptyTemplateGenericSheetModelTestPath,
+      name: bottomsheetName,
+      outputFolder: outputPath,
+    );
+
+    final fileExists = await _fileService.fileExists(filePath: filePath);
+    if (fileExists) {
+      await _fileService.deleteFile(filePath: filePath);
+    }
+  }
+
+  /// It removes the bottomsheet from [app.dart]
+  ///
+  /// Args:
+  ///
+  ///  `outputPath` (String): The path to the output folder.
+  ///
+  ///  `bottomsheetName` (String): The name of the bottomsheet.
+  Future<void> _removebottomsheetFromDependency(
+      {String? outputPath, required String bottomsheetName}) async {
+    String filePath = _templateService.getTemplateOutputPath(
+      inputTemplatePath: kAppMobileTemplateAppPath,
+      name: bottomsheetName,
+      outputFolder: outputPath,
+    );
+    await _fileService.removeSpecificFileLines(
+      filePath: filePath,
+      removedContent: bottomsheetName,
+      type: "sheet",
+    );
+  }
+}

--- a/lib/src/commands/delete/delete_command.dart
+++ b/lib/src/commands/delete/delete_command.dart
@@ -1,4 +1,5 @@
 import 'package:args/command_runner.dart';
+import 'package:stacked_cli/src/commands/delete/delete_bottomsheet_command.dart';
 import 'package:stacked_cli/src/commands/delete/delete_dialog_command.dart';
 import 'package:stacked_cli/src/commands/delete/delete_service_command.dart';
 
@@ -18,5 +19,6 @@ class DeleteCommand extends Command {
     addSubcommand(DeleteServiceCommand());
     addSubcommand(DeleteViewCommand());
     addSubcommand(DeleteDialogCommand());
+    addSubcommand(DeleteBottomsheetCommand());
   }
 }

--- a/lib/src/services/posthog_service.dart
+++ b/lib/src/services/posthog_service.dart
@@ -183,6 +183,20 @@ class PosthogService {
     );
   }
 
+  // Below event added if needed
+  Future<void> deleteBottomsheetEvent({
+    required String name,
+    required List<String> arguments,
+  }) async {
+    await _capture(
+      event: "Delete Bottom Sheet",
+      properties: {
+        "name": name,
+        "arguments": arguments,
+      },
+    );
+  }
+
   Future<void> deleteServiceEvent({
     required String name,
     required List<String> arguments,


### PR DESCRIPTION
### Feature Addition: Bottom Sheet Deletion Command

## Overview:
This pull request introduces a new feature to the Stacked CLI tool, enabling users to delete bottom sheets using a designated command. With this enhancement, users can now efficiently manage their application's UI components, enhancing flexibility and productivity.

Feature Details:

## Command Syntax: 
The newly added command follows the syntax: `stacked delete bottom_sheet <sheet_name>.` Users can specify the name of the bottom sheet they wish to delete, streamlining the deletion process.

## Functional Testing: 
Rigorous testing has been conducted to ensure the reliability and effectiveness of the new feature. Various scenarios and edge cases have been examined to verify the robustness of the implementation.

Thanks for such an amazing framework :)