### PR TITLE
feat: add format process on generate command

### DIFF
--- a/lib/src/commands/generate/generate_command.dart
+++ b/lib/src/commands/generate/generate_command.dart
@@ -41,6 +41,8 @@ class GenerateCommand extends Command {
   @override
   Future<void> run() async {
     try {
+      final workingDirectory = argResults!.rest.first;
+
       await _processService.runBuildRunner(
         shouldDeleteConflictingOutputs: argResults?[ksDeleteConflictOutputs],
         shouldWatch: argResults?[ksWatch],
@@ -48,6 +50,7 @@ class GenerateCommand extends Command {
       await _analyticsService.generateCodeEvent(
         arguments: argResults!.arguments,
       );
+      await _processService.runFormat(appName: workingDirectory);
     } catch (e, s) {
       _log.error(message: e.toString());
       unawaited(_analyticsService.logExceptionEvent(


### PR DESCRIPTION
This PR introduces a formatting process for the stacked generate command to ensure the generated files adhere to the user-defined line length. This enhancement aligns the behaviour of the stacked generate command with the stacked create command, which already formats files according to the specified line length.

**Context**:
Refer to the discussion [here](https://github.com/Stacked-Org/stacked/discussions/1109).

**Changes**:
- Added a dart format command execution at the end of the stacked generate process to ensure files are formatted according to the specified line length.
- Ensured that the formatting command respects the line-length option set by the user during the initial project creation.

