### PR TITLE
fix: enforce snake case app name

### DIFF
--- a/lib/src/commands/create/create_app_command.dart
+++ b/lib/src/commands/create/create_app_command.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:recase/recase.dart';
 import 'package:stacked_cli/src/constants/command_constants.dart';
 import 'package:stacked_cli/src/constants/config_constants.dart';
 import 'package:stacked_cli/src/constants/message_constants.dart';
@@ -80,8 +81,12 @@ class CreateAppCommand extends Command {
         configFilePath: argResults![ksConfigPath],
       );
 
-      final workingDirectory = argResults!.rest.first;
-      final appName = workingDirectory.split('/').last;
+      final List<String> workingDirectoryList =
+          argResults!.rest.first.split('/');
+      workingDirectoryList
+          .add(ReCase(workingDirectoryList.removeLast()).snakeCase);
+      final String appName = workingDirectoryList.last;
+      final String workingDirectory = workingDirectoryList.join('/');
       final templateType = argResults![ksTemplateType];
 
       _processService.formattingLineLength = argResults![ksLineLength];

--- a/lib/src/commands/create/create_app_command.dart
+++ b/lib/src/commands/create/create_app_command.dart
@@ -81,13 +81,25 @@ class CreateAppCommand extends Command {
         configFilePath: argResults![ksConfigPath],
       );
 
+      final templateType = argResults![ksTemplateType];
+
+      // appName validation and recasing
       final List<String> workingDirectoryList =
           argResults!.rest.first.split('/');
-      workingDirectoryList
-          .add(ReCase(workingDirectoryList.removeLast()).snakeCase);
-      final String appName = workingDirectoryList.last;
-      final String workingDirectory = workingDirectoryList.join('/');
-      final templateType = argResults![ksTemplateType];
+      final String originalAppName = workingDirectoryList.removeLast();
+      final String appName = ReCase(originalAppName).snakeCase;
+      if (originalAppName != appName) {
+        _log.info(
+            message:
+                '$originalAppName is not snake_case as required by dart, did you mean $appName? [Y/N]');
+        String input;
+        do {
+          input = stdin.readLineSync()?.toUpperCase().trim() ?? '';
+        } while (!(input == 'Y' || input == 'N'));
+        input == 'N' ? throw 'error: project name not snake_case' : {};
+      }
+      workingDirectoryList.add(appName);
+      final workingDirectory = workingDirectoryList.join('/');
 
       _processService.formattingLineLength = argResults![ksLineLength];
       await _processService.runCreateApp(


### PR DESCRIPTION
Checks if app name is snake_case when running: stacked create app. Fixes stacked-org/stacked#1081.

1. If app name is snake_case behaviour is unchanged.
2. If app name is not snake_case then user is prompted with `<originalAppName> is not snake_case as required by dart, did you mean <appName?> [Y/N]`. If they answer yes then the app name will be changed, if they answer no then the program will throw and exit with the message: `error: project name not snake_case`.