### PR TITLE
Feature create many

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 2.0.0-beta.0 (2024-10-17)
+
+### Features
+
+* Adds multi create functionality for views, services, dialogs and bottom sheets.
+
+Example: stacked create view -t web login signup dashboard home profile settings
+
+### Breaking Changes
+
+The names of the objects being created has to be last, meaning we now have an enforced order due to the implementation of this feature. 
+
+Docs and error messages has to be updated to reflect this change. 
+
+
 ## [1.13.1](https://github.com/Stacked-Org/cli/compare/v1.13.0...v1.13.1) (2024-07-02)
 
 

--- a/lib/src/commands/create/create_bottom_sheet_command.dart
+++ b/lib/src/commands/create/create_bottom_sheet_command.dart
@@ -58,6 +58,10 @@ class CreateBottomSheetCommand extends Command with ProjectStructureValidator {
         abbr: 'l',
         help: kCommandHelpLineLength,
         valueHelp: '80',
+      )
+      ..addOption(
+        ksProjectPath,
+        help: kCommandHelpProjectPath,
       );
   }
 
@@ -66,22 +70,20 @@ class CreateBottomSheetCommand extends Command with ProjectStructureValidator {
     try {
       final List<String> bottomSheetNames = argResults!.rest;
       final templateType = argResults![ksTemplateType];
-      // TODO: Find new way to pass workingDirectory
-      final workingDirectory =
-          argResults!.rest.length > 1 ? argResults!.rest[1] : null;
       await _configService.composeAndLoadConfigFile(
         configFilePath: argResults![ksConfigPath],
-        projectPath: workingDirectory,
+        projectPath: argResults![ksProjectPath],
       );
       _processService.formattingLineLength = argResults![ksLineLength];
-      await _pubspecService.initialise(workingDirectory: workingDirectory);
-      await validateStructure(outputPath: workingDirectory);
+      await _pubspecService.initialise(
+          workingDirectory: argResults![ksProjectPath]);
+      await validateStructure(outputPath: argResults![ksProjectPath]);
 
       for (var i = 0; i < bottomSheetNames.length; i++) {
         await _templateService.renderTemplate(
           templateName: name,
           name: bottomSheetNames[i],
-          outputPath: workingDirectory,
+          outputPath: argResults![ksProjectPath],
           verbose: true,
           excludeRoute: argResults![ksExcludeRoute],
           hasModel: argResults![ksModel],
@@ -94,7 +96,8 @@ class CreateBottomSheetCommand extends Command with ProjectStructureValidator {
         );
       }
 
-      await _processService.runBuildRunner(workingDirectory: workingDirectory);
+      await _processService.runBuildRunner(
+          workingDirectory: argResults![ksProjectPath]);
     } catch (e, s) {
       _log.error(message: e.toString());
       unawaited(_analyticsService.logExceptionEvent(

--- a/lib/src/commands/create/create_dialog_command.dart
+++ b/lib/src/commands/create/create_dialog_command.dart
@@ -58,6 +58,10 @@ class CreateDialogCommand extends Command with ProjectStructureValidator {
         abbr: 'l',
         help: kCommandHelpLineLength,
         valueHelp: '80',
+      )
+      ..addOption(
+        ksProjectPath,
+        help: kCommandHelpProjectPath,
       );
   }
 
@@ -66,22 +70,20 @@ class CreateDialogCommand extends Command with ProjectStructureValidator {
     try {
       final List<String> dialogNames = argResults!.rest;
       final templateType = argResults![ksTemplateType];
-      // TODO: Find new way to pass workingDirectory
-      final workingDirectory =
-          argResults!.rest.length > 1 ? argResults!.rest[1] : null;
       await _configService.composeAndLoadConfigFile(
         configFilePath: argResults![ksConfigPath],
-        projectPath: workingDirectory,
+        projectPath: argResults![ksProjectPath],
       );
       _processService.formattingLineLength = argResults![ksLineLength];
-      await _pubspecService.initialise(workingDirectory: workingDirectory);
-      await validateStructure(outputPath: workingDirectory);
+      await _pubspecService.initialise(
+          workingDirectory: argResults![ksProjectPath]);
+      await validateStructure(outputPath: argResults![ksProjectPath]);
 
       for (var i = 0; i < dialogNames.length; i++) {
         await _templateService.renderTemplate(
           templateName: name,
           name: dialogNames[i],
-          outputPath: workingDirectory,
+          outputPath: argResults![ksProjectPath],
           verbose: true,
           excludeRoute: argResults![ksExcludeRoute],
           hasModel: argResults![ksModel],
@@ -94,7 +96,8 @@ class CreateDialogCommand extends Command with ProjectStructureValidator {
         );
       }
 
-      await _processService.runBuildRunner(workingDirectory: workingDirectory);
+      await _processService.runBuildRunner(
+          workingDirectory: argResults![ksProjectPath]);
     } catch (e, s) {
       _log.error(message: e.toString());
       unawaited(_analyticsService.logExceptionEvent(

--- a/lib/src/commands/create/create_dialog_command.dart
+++ b/lib/src/commands/create/create_dialog_command.dart
@@ -64,8 +64,9 @@ class CreateDialogCommand extends Command with ProjectStructureValidator {
   @override
   Future<void> run() async {
     try {
-      final dialogName = argResults!.rest.first;
+      final List<String> dialogNames = argResults!.rest;
       final templateType = argResults![ksTemplateType];
+      // TODO: Find new way to pass workingDirectory
       final workingDirectory =
           argResults!.rest.length > 1 ? argResults!.rest[1] : null;
       await _configService.composeAndLoadConfigFile(
@@ -76,21 +77,24 @@ class CreateDialogCommand extends Command with ProjectStructureValidator {
       await _pubspecService.initialise(workingDirectory: workingDirectory);
       await validateStructure(outputPath: workingDirectory);
 
-      await _templateService.renderTemplate(
-        templateName: name,
-        name: dialogName,
-        outputPath: workingDirectory,
-        verbose: true,
-        excludeRoute: argResults![ksExcludeRoute],
-        hasModel: argResults![ksModel],
-        templateType: templateType,
-      );
+      for (var i = 0; i < dialogNames.length; i++) {
+        await _templateService.renderTemplate(
+          templateName: name,
+          name: dialogNames[i],
+          outputPath: workingDirectory,
+          verbose: true,
+          excludeRoute: argResults![ksExcludeRoute],
+          hasModel: argResults![ksModel],
+          templateType: templateType,
+        );
+
+        await _analyticsService.createDialogEvent(
+          name: dialogNames[i],
+          arguments: argResults!.arguments,
+        );
+      }
 
       await _processService.runBuildRunner(workingDirectory: workingDirectory);
-      await _analyticsService.createDialogEvent(
-        name: dialogName,
-        arguments: argResults!.arguments,
-      );
     } catch (e, s) {
       _log.error(message: e.toString());
       unawaited(_analyticsService.logExceptionEvent(

--- a/lib/src/commands/create/create_service_command.dart
+++ b/lib/src/commands/create/create_service_command.dart
@@ -53,6 +53,10 @@ class CreateServiceCommand extends Command with ProjectStructureValidator {
         abbr: 'l',
         help: kCommandHelpLineLength,
         valueHelp: '80',
+      )
+      ..addOption(
+        ksProjectPath,
+        help: kCommandHelpProjectPath,
       );
   }
 
@@ -61,22 +65,20 @@ class CreateServiceCommand extends Command with ProjectStructureValidator {
     try {
       final List<String> serviceNames = argResults!.rest;
       final templateType = argResults![ksTemplateType];
-      // TODO: Find new way to pass workingDirectory
-      final workingDirectory =
-          argResults!.rest.length > 1 ? argResults!.rest[1] : null;
       await _configService.composeAndLoadConfigFile(
         configFilePath: argResults![ksConfigPath],
-        projectPath: workingDirectory,
+        projectPath: argResults![ksProjectPath],
       );
       _processService.formattingLineLength = argResults?[ksLineLength];
-      await _pubspecService.initialise(workingDirectory: workingDirectory);
-      await validateStructure(outputPath: workingDirectory);
+      await _pubspecService.initialise(
+          workingDirectory: argResults![ksProjectPath]);
+      await validateStructure(outputPath: argResults![ksProjectPath]);
 
       for (var i = 0; i < serviceNames.length; i++) {
         await _templateService.renderTemplate(
           templateName: name,
           name: serviceNames[i],
-          outputPath: workingDirectory,
+          outputPath: argResults![ksProjectPath],
           verbose: true,
           excludeRoute: argResults![ksExcludeDependency],
           templateType: templateType,
@@ -88,7 +90,8 @@ class CreateServiceCommand extends Command with ProjectStructureValidator {
         );
       }
 
-      await _processService.runBuildRunner(workingDirectory: workingDirectory);
+      await _processService.runBuildRunner(
+          workingDirectory: argResults![ksProjectPath]);
     } catch (e, s) {
       _log.error(message: e.toString());
       unawaited(_analyticsService.logExceptionEvent(

--- a/lib/src/commands/create/create_service_command.dart
+++ b/lib/src/commands/create/create_service_command.dart
@@ -59,8 +59,9 @@ class CreateServiceCommand extends Command with ProjectStructureValidator {
   @override
   Future<void> run() async {
     try {
-      final serviceName = argResults!.rest.first;
+      final List<String> serviceNames = argResults!.rest;
       final templateType = argResults![ksTemplateType];
+      // TODO: Find new way to pass workingDirectory
       final workingDirectory =
           argResults!.rest.length > 1 ? argResults!.rest[1] : null;
       await _configService.composeAndLoadConfigFile(
@@ -71,19 +72,23 @@ class CreateServiceCommand extends Command with ProjectStructureValidator {
       await _pubspecService.initialise(workingDirectory: workingDirectory);
       await validateStructure(outputPath: workingDirectory);
 
-      await _templateService.renderTemplate(
-        templateName: name,
-        name: serviceName,
-        outputPath: workingDirectory,
-        verbose: true,
-        excludeRoute: argResults![ksExcludeDependency],
-        templateType: templateType,
-      );
+      for (var i = 0; i < serviceNames.length; i++) {
+        await _templateService.renderTemplate(
+          templateName: name,
+          name: serviceNames[i],
+          outputPath: workingDirectory,
+          verbose: true,
+          excludeRoute: argResults![ksExcludeDependency],
+          templateType: templateType,
+        );
+
+        await _analyticsService.createServiceEvent(
+          name: serviceNames[i],
+          arguments: argResults!.arguments,
+        );
+      }
+
       await _processService.runBuildRunner(workingDirectory: workingDirectory);
-      await _analyticsService.createServiceEvent(
-        name: serviceName,
-        arguments: argResults!.arguments,
-      );
     } catch (e, s) {
       _log.error(message: e.toString());
       unawaited(_analyticsService.logExceptionEvent(

--- a/lib/src/commands/create/create_view_command.dart
+++ b/lib/src/commands/create/create_view_command.dart
@@ -66,6 +66,7 @@ class CreateViewCommand extends Command with ProjectStructureValidator {
     try {
       final List<String> viewNames = argResults!.rest;
       var templateType = argResults![ksTemplateType] as String?;
+      // TODO: Find new way to pass workingDirectory
       final workingDirectory =
           argResults!.rest.length > 1 ? argResults!.rest[1] : null;
       await _configService.composeAndLoadConfigFile(

--- a/lib/src/commands/create/create_widget_command.dart
+++ b/lib/src/commands/create/create_widget_command.dart
@@ -57,6 +57,10 @@ class CreateWidgetCommand extends Command with ProjectStructureValidator {
         abbr: 'l',
         help: kCommandHelpLineLength,
         valueHelp: '80',
+      )
+      ..addOption(
+        ksProjectPath,
+        help: kCommandHelpProjectPath,
       );
   }
 
@@ -65,27 +69,24 @@ class CreateWidgetCommand extends Command with ProjectStructureValidator {
     try {
       final List<String> widgetNames = argResults!.rest;
       final templateType = argResults![ksTemplateType];
-      // TODO: Find new way to pass workingDirectory
-      final workingDirectory =
-          argResults!.rest.length > 1 ? argResults!.rest[1] : null;
-
       // load configuration
       await _configService.composeAndLoadConfigFile(
         configFilePath: argResults![ksConfigPath],
-        projectPath: workingDirectory,
+        projectPath: argResults![ksProjectPath],
       );
       // override [widgets_path] value on configuration
       _configService.setWidgetsPath(argResults![ksPath]);
 
       _processService.formattingLineLength = argResults![ksLineLength];
-      await _pubspecService.initialise(workingDirectory: workingDirectory);
-      await validateStructure(outputPath: workingDirectory);
+      await _pubspecService.initialise(
+          workingDirectory: argResults![ksProjectPath]);
+      await validateStructure(outputPath: argResults![ksProjectPath]);
 
       for (var i = 0; i < widgetNames.length; i) {
         await _templateService.renderTemplate(
           templateName: name,
           name: widgetNames[i],
-          outputPath: workingDirectory,
+          outputPath: argResults![ksProjectPath],
           verbose: true,
           hasModel: argResults![ksModel],
           templateType: templateType,

--- a/lib/src/commands/create/create_widget_command.dart
+++ b/lib/src/commands/create/create_widget_command.dart
@@ -63,8 +63,9 @@ class CreateWidgetCommand extends Command with ProjectStructureValidator {
   @override
   Future<void> run() async {
     try {
-      final widgetName = argResults!.rest.first;
+      final List<String> widgetNames = argResults!.rest;
       final templateType = argResults![ksTemplateType];
+      // TODO: Find new way to pass workingDirectory
       final workingDirectory =
           argResults!.rest.length > 1 ? argResults!.rest[1] : null;
 
@@ -80,19 +81,21 @@ class CreateWidgetCommand extends Command with ProjectStructureValidator {
       await _pubspecService.initialise(workingDirectory: workingDirectory);
       await validateStructure(outputPath: workingDirectory);
 
-      await _templateService.renderTemplate(
-        templateName: name,
-        name: widgetName,
-        outputPath: workingDirectory,
-        verbose: true,
-        hasModel: argResults![ksModel],
-        templateType: templateType,
-      );
+      for (var i = 0; i < widgetNames.length; i) {
+        await _templateService.renderTemplate(
+          templateName: name,
+          name: widgetNames[i],
+          outputPath: workingDirectory,
+          verbose: true,
+          hasModel: argResults![ksModel],
+          templateType: templateType,
+        );
 
-      await _analyticsService.createWidgetEvent(
-        name: widgetName,
-        arguments: argResults!.arguments,
-      );
+        await _analyticsService.createWidgetEvent(
+          name: widgetNames[i],
+          arguments: argResults!.arguments,
+        );
+      }
     } catch (e, s) {
       _log.error(message: e.toString());
       unawaited(_analyticsService.logExceptionEvent(

--- a/lib/src/constants/command_constants.dart
+++ b/lib/src/constants/command_constants.dart
@@ -1,4 +1,5 @@
 /// Stores all the commands used throughout the app that
+library;
 
 const String ksDart = 'dart';
 const String ksFlutter = 'flutter';
@@ -34,6 +35,7 @@ const String ksAppMinimalTemplate = 'empty';
 const String ksAppDescription = 'description';
 const String ksAppOrganization = 'org';
 const String ksAppPlatforms = 'platforms';
+const String ksProjectPath = 'project-path';
 
 /// A list of strings that are used to run the run build_runner
 /// [build or watch] --delete-conflicting-outputs command.

--- a/lib/src/constants/message_constants.dart
+++ b/lib/src/constants/message_constants.dart
@@ -1,5 +1,6 @@
 /// Stores all the messages used throughout the app that communicates
 /// with the user of the package.
+library;
 
 /// Message shown when we encounter a failure during generation that's caused by an invalid
 /// app structure.
@@ -100,4 +101,8 @@ Stacked config file should be renamed from "stacked.config.json" to "stacked.jso
 
 const String kDeprecatedPaths = '''
 Paths on Stacked config do not need to start with directory "lib" or "test" because  are mandatory directories, defined by the Flutter framework. Stacked cli will not accept paths starting with "lib" or "test" after the next minor release.
+''';
+
+const String kCommandHelpProjectPath = '''
+When path is provided, it will be considered the project directory instead of the current directory.
 ''';

--- a/lib/src/services/pub_service.dart
+++ b/lib/src/services/pub_service.dart
@@ -20,8 +20,12 @@ class PubService {
     final packages = await _processService.runPubGlobalList();
     for (var package in packages) {
       if (!package.contains(ksStackedCli)) continue;
-
-      version = package.split(' ').last;
+      final splitResults = package.split(' ');
+      if (splitResults.length > 2) {
+        version = splitResults[1];
+      } else {
+        version = splitResults.last;
+      }
       break;
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_cli
 description: The official dev tools for the Stacked Framework
-version: 1.14.0-beta.0
+version: 2.0.0-beta.0
 homepage: https://stacked.filledstacks.com/docs/stacked-cli
 repository: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_cli
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_cli
 description: The official dev tools for the Stacked Framework
-version: 1.13.1
+version: 1.14.0-beta.0
 homepage: https://stacked.filledstacks.com/docs/stacked-cli
 repository: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_cli
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,4 +32,4 @@ dev_dependencies:
   json_serializable: ^6.7.1
 
 executables:
-  stacked2:
+  stacked:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://stacked.filledstacks.com/docs/stacked-cli
 repository: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_cli
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: ">=2.19.0 <4.0.0"
 
 dependencies:
   args: ^2.4.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   args: ^2.4.2
   freezed_annotation: ^2.1.0
-  get_it: ^7.6.0
+  get_it: ^8.0.3
   mockito: ^5.4.3
   mustache_template: ^2.0.0
   path: ^1.8.1
@@ -19,12 +19,12 @@ dependencies:
   json_annotation: ^4.8.1
   ansicolor: ^2.0.2
   xdg_directories: ^1.0.0
-  pub_updater: ^0.4.0
+  pub_updater: ^0.5.0
   http: ^1.1.2
   hive: ^2.2.3
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: ^5.1.1
   test: ^1.16.0
 
   build_runner: ^2.4.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,4 +32,4 @@ dev_dependencies:
   json_serializable: ^6.7.1
 
 executables:
-  stacked:
+  stacked2:


### PR DESCRIPTION
EDIT: Changed working directory flag name from `--output` to `--project-path` due to previuos missunderstanding of it's purpose.

Proposed solution for creating multiple services, viewModels, etc with `stacked create`. It seems to me that we will be unable to have the working directory argument remain unnamed as before. I propose making it a flag like `--output` or something similar.
Fixes Stacked-Org/stacked#917

- [x] Multiple views creation
- [x] Multiple services createion
- [x] Multiple dialogs creation
- [x] Multiple widget creation
- [x] Multiple bottom sheet creation
- [x] Change workingDirectory argument to flag.