### PR TITLE
Migrate from `pubspec_yaml` to `yaml` and improve version parsing on Windows

### DIFF
--- a/lib/src/services/pubspec_service.dart
+++ b/lib/src/services/pubspec_service.dart
@@ -1,21 +1,21 @@
 import 'dart:io';
 
-import 'package:pubspec_yaml/pubspec_yaml.dart';
+import 'package:yaml/yaml.dart';
 
 /// Provides functionality to interact with the pubspec in the current project
 class PubspecService {
-  late PubspecYaml pubspecYaml;
+  late YamlMap pubspecYaml;
 
-  /// Reads the pubpec and caches the value locally
+  /// Reads the pubspec and caches the value locally
   Future<void> initialise({String? workingDirectory}) async {
     final bool hasWorkingDirectory = workingDirectory != null;
     // stdout.writeln('PubspecService - initialise from pubspec.yaml');
-    final pubspecYamlContent = await File(
-            '${hasWorkingDirectory ? '$workingDirectory/' : ''}pubspec.yaml')
-        .readAsString();
-    pubspecYaml = pubspecYamlContent.toPubspecYaml();
+    final pubspecYamlContent =
+        await File('${hasWorkingDirectory ? '$workingDirectory/' : ''}pubspec.yaml').readAsString();
+
+    pubspecYaml = loadYaml(pubspecYamlContent) as YamlMap;
     // stdout.writeln('PubspecService - initialise complete');
   }
 
-  String get getPackageName => pubspecYaml.name;
+  String get getPackageName => pubspecYaml['name'];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   mockito: ^5.4.3
   mustache_template: ^2.0.0
   path: ^1.8.1
-  pubspec_yaml: ^3.1.0
+  yaml: ^3.1.3
   recase: ^4.0.0
   json_annotation: ^4.8.1
   ansicolor: ^2.0.2


### PR DESCRIPTION
## Summary
Replaced `pubspec_yaml` with `yaml` for parsing `pubspec.yaml`, as `pubspec_yaml` has not been updated for three years and breaks when parsing `pubspec.yaml` files containing modern dependency imports from external pub servers with the `hosted` parameter.

## Reproduction Example
To reproduce the issue, add the following dependency to `pubspec.yaml`:
```yaml
isar_generator:
  hosted: https://pub.isar-community.dev
  version: 3.1.8
```
The `pubspec_yaml` parser fails to handle this format correctly.

## Additional Fixes
- Improved version parsing. Previously, when running locally on Windows, the extracted version string included an unwanted path at the end. This issue has been resolved.



