### PR TITLE
Have stacked command log errors and exit on failed subcommand

### DIFF
--- a/lib/src/exceptions/stacked_process_failed_exception.dart
+++ b/lib/src/exceptions/stacked_process_failed_exception.dart
@@ -1,0 +1,7 @@
+class StackedProcessFailedException implements Exception {
+  final dynamic msg;
+  StackedProcessFailedException(this.msg);
+
+  @override
+  toString() => msg.toString();
+}

--- a/lib/src/services/process_service.dart
+++ b/lib/src/services/process_service.dart
@@ -137,6 +137,7 @@ class ProcessService {
   }
 
   /// It runs a process and logs the output to the console when [verbose] is true.
+  /// Will throw if the process errors out and won't run any subsequent processes.
   ///
   /// Args:
   ///   programName (String): The name of the program to run.

--- a/lib/src/services/process_service.dart
+++ b/lib/src/services/process_service.dart
@@ -192,7 +192,7 @@ class ProcessService {
 
       await for (final value in groupedStream) {
         if (value.id == 'error') {
-          _cLog.error(message: value.value);
+          throw SubCommandException(value.value);
         } else if (value.id == 'info' && verbose) {
           _cLog.flutterOutput(message: value.value);
         }
@@ -220,6 +220,8 @@ class ProcessService {
         message: message,
         stackTrace: s.toString(),
       );
+    } on SubCommandException catch (e, _) {
+      rethrow;
     } catch (e, s) {
       final message =
           'Command failed. Command executed: $programName ${arguments.join(' ')}\nException: ${e.toString()}';
@@ -255,4 +257,12 @@ class IdStreamResponse<T> {
   final T value;
 
   IdStreamResponse(this.id, this.value);
+}
+
+class SubCommandException implements Exception {
+  final dynamic msg;
+  SubCommandException(this.msg);
+
+  @override
+  toString() => msg.toString();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   pub_updater: ^0.4.0
   http: ^1.1.2
   hive: ^2.2.3
+  async: ^2.13.0
 
 dev_dependencies:
   lints: ^3.0.0


### PR DESCRIPTION
When working with the CLI I noticed that errors are not logged to CLI when running Stacked commands.

This PR aims to do the following:
1. Make sure info as well as errors are logged.
2. Have the program exit when a subcommand errors and not run subsequent subcommands