### PR TITLE
fix: format only source directories, skip build/

### DIFF
--- a/lib/src/constants/command_constants.dart
+++ b/lib/src/constants/command_constants.dart
@@ -38,6 +38,14 @@ const String ksAppPlatforms = 'platforms';
 const String ksProjectPath = 'project-path';
 const String ksNoTest = 'no-test';
 
+/// Source directories to format when no explicit file path is provided.
+const List<String> formatSourceDirectories = [
+  'lib',
+  'test',
+  'integration_test',
+  'bin',
+];
+
 /// A list of strings that are used to run the run build_runner
 /// [build or watch] --delete-conflicting-outputs command.
 const List<String> buildRunnerArguments = [

--- a/lib/src/services/process_service.dart
+++ b/lib/src/services/process_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
 import 'package:stacked_cli/src/constants/command_constants.dart';
 import 'package:stacked_cli/src/locator.dart';
 import 'package:stacked_cli/src/services/colorized_log_service.dart';
@@ -81,21 +82,40 @@ class ProcessService {
     );
   }
 
-  /// Runs the dart format . command on the app's source code.
+  /// Runs dart format on the app's source directories.
+  ///
+  /// When [filePath] is provided, only that path is formatted. Otherwise,
+  /// existing directories from [formatSourceDirectories] are formatted.
   ///
   /// Args:
   ///   appName (String): The name of the app.
   Future<void> runFormat({String? appName, String? filePath}) async {
+    final formatPaths =
+        filePath != null ? [filePath] : await _resolveFormatPaths(appName);
+
     await _runProcess(
       programName: ksDart,
       arguments: [
         ksFormat,
-        filePath ?? ksCurrentDirectory,
+        ...formatPaths,
         '-l',
-        _formattingLineLength
+        _formattingLineLength,
       ],
       workingDirectory: appName,
     );
+  }
+
+  Future<List<String>> _resolveFormatPaths(String? workingDirectory) async {
+    final base = workingDirectory ?? Directory.current.path;
+    final paths = <String>[];
+
+    for (final dir in formatSourceDirectories) {
+      if (await Directory(p.join(base, dir)).exists()) {
+        paths.add(dir);
+      }
+    }
+
+    return paths.isEmpty ? [ksCurrentDirectory] : paths;
   }
 
   /// It runs the `dart pub global activate` command in the app's directory

--- a/test/services/process_service_test.dart
+++ b/test/services/process_service_test.dart
@@ -12,7 +12,8 @@ void main() {
     setUp(() => registerServices());
     tearDown(() => locator.reset());
     group('runFormat -', () {
-      test('when called should run dart format . and finish in exit code 0',
+      test(
+          'when called should format source directories and finish in exit code 0',
           () async {
         var clog = getAndRegisterColorizedLogService();
         var service = _getService();
@@ -21,12 +22,19 @@ void main() {
       });
 
       test(
-          'when called should run dart format . and ouput error if appName is not found',
+          'when called should format source directories and output error if appName is not found',
           () async {
         var clog = getAndRegisterColorizedLogService();
         var service = _getService();
         await service.runFormat(appName: "xyz");
         verify(clog.error(message: anyNamed('message')));
+      });
+
+      test('when filePath is provided should format only that path', () async {
+        var clog = getAndRegisterColorizedLogService();
+        var service = _getService();
+        await service.runFormat(filePath: 'lib');
+        verify(clog.success(message: 'Command complete. ExitCode: 0'));
       });
     });
   });


### PR DESCRIPTION
## Summary
- Changes `dart format .` to format only existing source directories (`lib`, `test`, `integration_test`, `bin`)
- Prevents formatting third-party sources under `build/ios/SourcePackages` introduced by Flutter 3.44 SPM

Fixes Stacked-Org/stacked#1189

Refs: https://github.com/dart-lang/dart_style/issues/1840

## Test plan
- [x] `dart test` passes in stacked_cli
- [x] `stacked generate` runs `dart format lib test bin -l 80` instead of `dart format .`
- [x] `stacked generate` on Flutter 3.44 + Firebase project only formats project source files